### PR TITLE
i18n: add repetitionPenalty and verbosity translations

### DIFF
--- a/src/lang/cn.ts
+++ b/src/lang/cn.ts
@@ -579,6 +579,8 @@ export const languageChinese = {
     temperature: "温度（Temperature）",
     frequencyPenalty: "频率惩罚（Frequency Penalty）",
     presensePenalty: "存在惩罚（Presence Penalty）",
+    repetitionPenalty: "重复惩罚（Repetition Penalty）",
+    verbosity: "详细程度（Verbosity）",
     advancedSettings: "高级设置",
     advancedSettingsWarn: "警告：若不确定该选项的作用，请勿进行修改！",
     formatingOrder: "格式顺序",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -617,6 +617,8 @@ export const languageGerman = {
     temperature: "Temperatur",
     frequencyPenalty: "Häufigkeitslimitierung",
     presensePenalty: "Auftrittslimitierung",
+    repetitionPenalty: "Wiederholungsstrafe",
+    verbosity: "mức độ chi tiết",
     advancedSettings: "Erweitert",
     advancedSettingsWarn: "Warnung: Bitte ändern Sie die folgenden Optionen nicht, wenn Sie nicht exakt wissen, was diese bewirken!",
     formatingOrder: "Formatreihenfolge",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -639,6 +639,8 @@ export const languageEnglish = {
     temperature: "Temperature",
     frequencyPenalty: "Frequency Penalty",
     presensePenalty: "Presense Penalty",
+    repetitionPenalty: "Repetition Penalty",
+    verbosity: "Verbosity",
     advancedSettings: "Advanced Settings",
     advancedSettingsWarn: "Warn: If you don't know what the option does, don't change it!",
     formatingOrder: "Formating Order",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -609,6 +609,8 @@ export const languageSpanish = {
     temperature: "Temperatura",
     frequencyPenalty: "Penalización por Frecuencia",
     presensePenalty: "Penalización por Presencia",
+    repetitionPenalty: "penalización por repetición",
+    verbosity: "verbosidad",
     advancedSettings: "Configuraciones Avanzadas",
     advancedSettingsWarn: "Advertencia: ¡Si no sabes lo que hace la opción, no la cambies!",
     formatingOrder: "Orden de Formateo",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -590,6 +590,8 @@ export const languageKorean = {
     temperature: "온도",
     frequencyPenalty: "빈도 패널티",
     presensePenalty: "프리센스 패널티",
+    repetitionPenalty: "반복 패널티",
+    verbosity: "상세도 (Verbosity)",
     advancedSettings: "고급 설정",
     advancedSettingsWarn: "어떤 설정인지 모르겠으면, 만지지 마세요!",
     formatingOrder: "포맷 순서",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -602,6 +602,8 @@ export const LanguageVietnamese = {
     temperature: "Nhiệt độ",
     frequencyPenalty: "Hình phạt tần số",
     presensePenalty: "Hình phạt có mặt",
+    repetitionPenalty: "hình phạt lặp lại",
+    verbosity: "mức độ chi tiết",
     advancedSettings: "Cài đặt nâng cao",
     advancedSettingsWarn: "Cảnh báo: Nếu bạn không biết tùy chọn này làm gì, đừng thay đổi nó!",
     formatingOrder: "Thứ tự hình thành",

--- a/src/lang/zh-Hant.ts
+++ b/src/lang/zh-Hant.ts
@@ -581,6 +581,8 @@ export const languageChineseTraditional = {
     temperature: "溫度（Temperature）",
     frequencyPenalty: "頻率懲罰（Frequency Penalty）",
     presensePenalty: "存在懲罰（Presence Penalty）",
+    repetitionPenalty: "重複懲罰（Repetition Penalty）",
+    verbosity: "詳細程度（Verbosity）",
     advancedSettings: "進階設定",
     advancedSettingsWarn: "警告：若不確定該選項的作用，請勿進行修改！",
     formatingOrder: "格式順序",


### PR DESCRIPTION
# Description
Add translations for repetitionPenalty and verbosity settings across 7 language files:
- Chinese (cn)
- German (de)
- English (en)
- Spanish (es)
- Korean (ko)
- Vietnamese (vi)
- Traditional Chinese (zh-Hant)