### PR TITLE
refactor: Migrate some Svelte stores to Svelte 5 runes ($state)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { layoutState, settingsOpen, sideBarState, realmState, modalState, MobileGUI, appState, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
+    import { layoutState, settingsOpen, sideBarState, realmState, modalState, appState, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -33,6 +33,8 @@
     let gridOpen = $state(false)
     let aprilFools = $state(new Date().getMonth() === 3 && new Date().getDate() === 1)
     let aprilFoolsPage = $state(0)
+
+    let betaMobileSearch = $state('');
 
     // Drag and drop handlers
     function handleDragOver(e: DragEvent) {
@@ -149,10 +151,10 @@
         <WelcomeRisu />
     {:else if $settingsOpen}
         <Settings />
-    {:else if $MobileGUI}
+    {:else if layoutState.betaMobile.enabled}
         <div class="w-full h-full flex flex-col">
-            <MobileHeader />
-            <MobileBody />
+            <MobileHeader bind:search={betaMobileSearch}/>
+            <MobileBody search={betaMobileSearch}/>
             <MobileFooter />
         </div>
     {:else}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DynamicGUI, settingsOpen, sideBarState, ShowRealmFrameStore, openPresetList, openPersonaList, MobileGUI, loadedStore, alertStore, LoadingStatusState, bookmarkListOpen, popupStore } from './ts/stores.svelte';
+    import { DynamicGUI, settingsOpen, sideBarState, ShowRealmFrameStore, modalState, MobileGUI, loadedStore, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -183,13 +183,13 @@
     {#if $ShowRealmFrameStore}
         <RealmFrame />
     {/if}
-    {#if $openPresetList}
-        <Botpreset close={() => {$openPresetList = false}} />
+    {#if modalState.preset}
+        <Botpreset close={() => {modalState.preset = false}} />
     {/if}
-    {#if $openPersonaList}
-        <ListedPersona close={() => {$openPersonaList = false}} />
+    {#if modalState.persona}
+        <ListedPersona close={() => {modalState.persona = false}} />
     {/if}
-    {#if $bookmarkListOpen}
+    {#if modalState.bookmark}
         <BookmarkList />
     {/if}
     {#if $hypaV3ModalOpen}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DynamicGUI, settingsOpen, sideBarState, realmState, modalState, MobileGUI, loadedStore, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
+    import { DynamicGUI, settingsOpen, sideBarState, realmState, modalState, MobileGUI, appState, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -133,7 +133,7 @@
             </div>
             <span class="absolute top-4 left-4 font-bold text-[#bbbbbb] text-md md:text-lg">RisyGTP-9</span>
         </div>
-    {:else if !$loadedStore}
+    {:else if !appState.loaded}
         <div class="w-full h-full flex justify-center items-center text-textcolor text-xl bg-gray-900 flex-col">
             <div class="flex flex-row items-center">
                 <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-textcolor" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DynamicGUI, settingsOpen, sideBarState, realmState, modalState, MobileGUI, appState, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
+    import { layoutState, settingsOpen, sideBarState, realmState, modalState, MobileGUI, appState, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -159,7 +159,7 @@
         {#if gridOpen}
             <GridChars endGrid={() => {gridOpen = false}} />
         {:else}
-            {#if (!$DynamicGUI)}
+            {#if (!layoutState.compactMode)}
                 <Sidebar openGrid={() => {gridOpen = true}} hidden={!sideBarState.open} />
             {:else}
                 <div class="top-0 w-full h-full left-0 z-30 flex flex-row items-center" class:fixed={sideBarState.open} class:hidden={!sideBarState.open} >

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DynamicGUI, settingsOpen, sideBarStore, ShowRealmFrameStore, openPresetList, openPersonaList, MobileGUI, loadedStore, alertStore, LoadingStatusState, bookmarkListOpen, popupStore } from './ts/stores.svelte';
+    import { DynamicGUI, settingsOpen, sideBarState, ShowRealmFrameStore, openPresetList, openPersonaList, MobileGUI, loadedStore, alertStore, LoadingStatusState, bookmarkListOpen, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -160,9 +160,9 @@
             <GridChars endGrid={() => {gridOpen = false}} />
         {:else}
             {#if (!$DynamicGUI)}
-                <Sidebar openGrid={() => {gridOpen = true}} hidden={!$sideBarStore} />
+                <Sidebar openGrid={() => {gridOpen = true}} hidden={!sideBarState.open} />
             {:else}
-                <div class="top-0 w-full h-full left-0 z-30 flex flex-row items-center" class:fixed={$sideBarStore} class:hidden={!$sideBarStore} >
+                <div class="top-0 w-full h-full left-0 z-30 flex flex-row items-center" class:fixed={sideBarState.open} class:hidden={!sideBarState.open} >
                     <Sidebar openGrid={() => {gridOpen = true}}  hidden={false} />
 
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DynamicGUI, settingsOpen, sideBarState, ShowRealmFrameStore, modalState, MobileGUI, loadedStore, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
+    import { DynamicGUI, settingsOpen, sideBarState, realmState, modalState, MobileGUI, loadedStore, alertStore, LoadingStatusState, popupStore } from './ts/stores.svelte';
     import Sidebar from './lib/SideBars/Sidebar.svelte';
     import { DBState } from './ts/stores.svelte';
     import ChatScreen from './lib/ChatScreens/ChatScreen.svelte';
@@ -9,7 +9,7 @@
     import WelcomeRisu from './lib/Others/WelcomeRisu.svelte';
     import BookmarkList from './lib/Others/BookmarkList.svelte';
     import Settings from './lib/Setting/Settings.svelte';
-    import { showRealmInfoStore, importCharacterProcess } from './ts/characterCards';
+    import { showRealmInfoStore, importCharacterProcess } from './ts/characterCards.svelte';
     import { importPreset } from './ts/storage/preset-manager';
     import { importModuleFromData } from './ts/process/modules';
     import { alertNormal } from './ts/alert';
@@ -180,7 +180,7 @@
     {#if $showRealmInfoStore}
         <RealmPopUp bind:openedData={$showRealmInfoStore} />
     {/if}
-    {#if $ShowRealmFrameStore}
+    {#if realmState.uploadTarget}
         <RealmFrame />
     {/if}
     {#if modalState.preset}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,7 +23,7 @@
     import MobileFooter from './lib/Mobile/MobileFooter.svelte';
     import { checkCharOrder } from './ts/globalApi.svelte';
     import { ArrowUpIcon, GlobeIcon, PlusIcon } from '@lucide/svelte';
-    import { hypaV3ModalOpen, hypaV3ProgressStore } from "./ts/stores.svelte";
+    import { hypaV3State } from "./ts/stores.svelte";
     import HypaV3Modal from './lib/Others/HypaV3Modal.svelte';
     import HypaV3Progress from './lib/Others/HypaV3Progress.svelte';
     import PluginAlertModal from './lib/Others/PluginAlertModal.svelte';
@@ -192,11 +192,11 @@
     {#if modalState.bookmark}
         <BookmarkList />
     {/if}
-    {#if $hypaV3ModalOpen}
+    {#if hypaV3State.open}
         <HypaV3Modal />
     {/if}
     <SavePopupIconComp />
-    {#if $hypaV3ProgressStore.open}
+    {#if hypaV3State.progress.open}
         <HypaV3Progress />
     {/if}
     <PluginAlertModal />

--- a/src/LiteMain.svelte
+++ b/src/LiteMain.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { downloadRisuHub, getRisuHub } from "src/ts/characterCards";
+    import { downloadRisuHub, getRisuHub } from "src/ts/characterCards.svelte";
     import LiteCardIcon from "./lib/LiteUI/LiteCardIcon.svelte";
   import { selectedCharID } from "./ts/stores.svelte";
   import DefaultChatScreen from "./lib/ChatScreens/DefaultChatScreen.svelte";

--- a/src/lib/ChatScreens/ChatScreen.svelte
+++ b/src/lib/ChatScreens/ChatScreen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getCustomBackground, getEmotion } from "../../ts/characters";
+    import { getCustomBackground, getEmotion } from "../../ts/characters.svelte";
     
     import { DBState } from 'src/ts/stores.svelte';
     import { CharEmotion, ShowVN, selectedCharID } from "../../ts/stores.svelte";

--- a/src/lib/ChatScreens/ChatScreen.svelte
+++ b/src/lib/ChatScreens/ChatScreen.svelte
@@ -2,7 +2,7 @@
     import { getCustomBackground, getEmotion } from "../../ts/characters.svelte";
     
     import { DBState } from 'src/ts/stores.svelte';
-    import { CharEmotion, ShowVN, selectedCharID } from "../../ts/stores.svelte";
+    import { CharEmotion, layoutState, selectedCharID } from "../../ts/stores.svelte";
     import ResizeBox from './ResizeBox.svelte'
     import DefaultChatScreen from "./DefaultChatScreen.svelte";
     import defaultWallpaper from '../../etc/bg.jpg'
@@ -33,7 +33,7 @@
     });
 </script>
 
-{#if $ShowVN}
+{#if layoutState.ShowVN}
     <VisualNovelMain />
 {:else if DBState.db.theme === 'waifu'}
     <div class="grow h-full flex justify-center relative" style="{bgImg.length < 4 ? wallPaper : bgImg}">

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -3,7 +3,7 @@
     import type { character, groupChat } from 'src/ts/storage/types/character';
     import { mount, onDestroy, unmount } from 'svelte';
     import Chat from './Chat.svelte';
-    import { getCharImage } from 'src/ts/characters';
+    import { getCharImage } from 'src/ts/characters.svelte';
     import { createSimpleCharacter } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
 

--- a/src/lib/ChatScreens/DefaultChatScreen.next.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.next.svelte
@@ -8,10 +8,10 @@
     import type { Message } from "../../ts/storage/types/chat";
     import type { character, groupChat } from "../../ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
-    import { getCharImage } from "../../ts/characters";
+    import { getCharImage } from "../../ts/characters.svelte";
     import { chatProcessStage, doingChat, sendChat } from "../../ts/process/index.svelte";
     import { sleep } from "../../ts/util";
-    import { findCharacterbyId } from "../../ts/characters";
+    import { findCharacterbyId } from "../../ts/characters.svelte";
     import { language } from "../../lang";
     import { isExpTranslator, translate } from "../../ts/translator/translator";
     import { alertError, alertNormal, alertWait, showHypaV2Alert } from "../../ts/alert";

--- a/src/lib/ChatScreens/DefaultChatScreen.next.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.next.svelte
@@ -3,7 +3,7 @@
     import Suggestion from './Suggestion.svelte';
     import AdvancedChatEditor from './AdvancedChatEditor.svelte';
     import { CameraIcon, DatabaseIcon, DicesIcon, GlobeIcon, ImagePlusIcon, LanguagesIcon, Laugh, MenuIcon, MicOffIcon, PackageIcon, Plus, RefreshCcwIcon, ReplyIcon, Send, StepForwardIcon, XIcon, BrainIcon } from "@lucide/svelte";
-    import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3ModalOpen } from "../../ts/stores.svelte";
+    import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3State } from "../../ts/stores.svelte";
     import Chat from "./Chat.svelte";
     import type { Message } from "../../ts/storage/types/chat";
     import type { character, groupChat } from "../../ts/storage/types/character";
@@ -844,7 +844,7 @@
                                     }
                                     showHypaV2Alert()
                                 } else if (DBState.db.hypaV3) {
-                                    $hypaV3ModalOpen = true
+                                    hypaV3State.open = true
                                 }
 
                                 openMenu = false

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -3,7 +3,7 @@
     import Suggestion from './Suggestion.svelte';
     import AdvancedChatEditor from './AdvancedChatEditor.svelte';
     import { CameraIcon, DatabaseIcon, DicesIcon, GlobeIcon, ImagePlusIcon, LanguagesIcon, Laugh, MenuIcon, MicOffIcon, PackageIcon, Plus, RefreshCcwIcon, ReplyIcon, Send, StepForwardIcon, XIcon, BrainIcon } from "@lucide/svelte";
-    import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3ModalOpen, ScrollToMessageStore } from "../../ts/stores.svelte";
+    import { selectedCharID, PlaygroundStore, createSimpleCharacter, hypaV3State, ScrollToMessageStore } from "../../ts/stores.svelte";
     import { tick } from 'svelte';
     import Chat from "./Chat.svelte";
     import { type Message } from "../../ts/storage/types/chat";
@@ -883,7 +883,7 @@
                                     }
                                     showHypaV2Alert();
                                 } else if (DBState.db.hypaV3) {
-                                    $hypaV3ModalOpen = true
+                                    hypaV3State.open = true
                                 }
 
                                 openMenu = false

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -8,7 +8,7 @@
     import Chat from "./Chat.svelte";
     import { type Message } from "../../ts/storage/types/chat";
     import { DBState } from 'src/ts/stores.svelte';
-    import { getCharImage } from "../../ts/characters";
+    import { getCharImage } from "../../ts/characters.svelte";
     import { chatProcessStage, doingChat, sendChat } from "../../ts/process/index.svelte";
     import { sleep } from "../../ts/util";
     import { language } from "../../lang";

--- a/src/lib/ChatScreens/ResizeBox.svelte
+++ b/src/lib/ChatScreens/ResizeBox.svelte
@@ -2,7 +2,7 @@
     import { CharEmotion, ViewBoxsize } from '../../ts/stores.svelte';
     import { onMount } from 'svelte';
     import TransitionImage from './TransitionImage.svelte';
-    import { getEmotion } from 'src/ts/characters';
+    import { getEmotion } from 'src/ts/characters.svelte';
     
     import { DBState } from 'src/ts/stores.svelte';
 

--- a/src/lib/LiteUI/LiteCardIcon.svelte
+++ b/src/lib/LiteUI/LiteCardIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-    import { type hubType } from "src/ts/characterCards";
+    import { type hubType } from "src/ts/characterCards.svelte";
     interface Props {
         card: hubType;
         onclick?: (event: MouseEvent & {

--- a/src/lib/Mobile/MobileBody.svelte
+++ b/src/lib/Mobile/MobileBody.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { MobileGUIStack, MobileSideBar, selectedCharID } from "src/ts/stores.svelte";
+    import { layoutState, selectedCharID } from "src/ts/stores.svelte";
     import Settings from "../Setting/Settings.svelte";
     import RealmMain from "../UI/Realm/RealmMain.svelte";
     import MobileCharacters from "./MobileCharacters.svelte";
@@ -12,45 +12,47 @@
     import { isLite } from "src/ts/lite";
     
     import { DBState } from 'src/ts/stores.svelte';
+    
+    let { search } = $props();
 </script>
 
-{#if $MobileSideBar > 0 && !$isLite}
+{#if layoutState.betaMobile.sideBar > 0 && !$isLite}
 <div class="w-full px-2 py-1 text-textcolor2 border-b border-b-darkborderc bg-darkbg flex justify-start items-center gap-2">
-    <button class="flex-1 border-r border-r-darkborderc" class:text-textcolor={$MobileSideBar === 1} onclick={() => {
-        $MobileSideBar = 1
+    <button class="flex-1 border-r border-r-darkborderc" class:text-textcolor={layoutState.betaMobile.sideBar === 1} onclick={() => {
+        layoutState.betaMobile.sideBar = 1
     }}>
         {language.Chat}
     </button>
-    <button class="flex-1 border-r border-r-darkborderc" class:text-textcolor={$MobileSideBar === 2} onclick={() => {
-        $MobileSideBar = 2
+    <button class="flex-1 border-r border-r-darkborderc" class:text-textcolor={layoutState.betaMobile.sideBar === 2} onclick={() => {
+        layoutState.betaMobile.sideBar = 2
     }}>
         {language.character}
     </button>
-    <button class:text-textcolor={$MobileSideBar === 3} onclick={() => {
-        $MobileSideBar = 3
+    <button class:text-textcolor={layoutState.betaMobile.sideBar === 3} onclick={() => {
+        layoutState.betaMobile.sideBar = 3
     }}>
         <WrenchIcon size={18} />
     </button>
 </div>
 {/if}
 <div class="w-full flex-1 overflow-y-auto bg-bgcolor relative">
-    {#if $MobileSideBar > 0}
+    {#if layoutState.betaMobile.sideBar > 0}
         <div class="w-full flex flex-col p-2 mt-2 h-full">
-            {#if $MobileSideBar === 1}
+            {#if layoutState.betaMobile.sideBar === 1}
                 <SideChatList bind:chara={DBState.db.characters[$selectedCharID]} />
-            {:else if $MobileSideBar === 2}
+            {:else if layoutState.betaMobile.sideBar === 2}
                 <CharConfig />
-            {:else if $MobileSideBar === 3}
+            {:else if layoutState.betaMobile.sideBar === 3}
                 <DevTool />
             {/if}
         </div>
     {:else if $selectedCharID !== -1}
         <ChatScreen />
-    {:else if $MobileGUIStack === 0}
+    {:else if layoutState.betaMobile.stack === 0}
         <RealmMain />
-    {:else if $MobileGUIStack === 1}
-        <MobileCharacters />
-    {:else if $MobileGUIStack === 2}
+    {:else if layoutState.betaMobile.stack === 1}
+        <MobileCharacters search={search}/>
+    {:else if layoutState.betaMobile.stack === 2}
         <Settings />
     {/if}
 </div>

--- a/src/lib/Mobile/MobileCharacters.svelte
+++ b/src/lib/Mobile/MobileCharacters.svelte
@@ -2,7 +2,7 @@
     import type { character, groupChat } from "src/ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
     import BarIcon from "../SideBars/BarIcon.svelte";
-    import { addCharacter, changeChar, getCharImage } from "src/ts/characters";
+    import { addCharacter, changeChar, getCharImage } from "src/ts/characters.svelte";
     import { MobileSearch } from "src/ts/stores.svelte";
     import { MessageSquareIcon, PlusIcon } from "@lucide/svelte";
 

--- a/src/lib/Mobile/MobileCharacters.svelte
+++ b/src/lib/Mobile/MobileCharacters.svelte
@@ -3,17 +3,17 @@
     import { DBState } from 'src/ts/stores.svelte';
     import BarIcon from "../SideBars/BarIcon.svelte";
     import { addCharacter, changeChar, getCharImage } from "src/ts/characters.svelte";
-    import { MobileSearch } from "src/ts/stores.svelte";
     import { MessageSquareIcon, PlusIcon } from "@lucide/svelte";
 
     interface Props {
         gridMode?: boolean;
         endGrid?: () => void;
+        search?: string;
     }
 
     const agoFormatter = new Intl.RelativeTimeFormat(navigator.languages, { style: 'short' });
 
-    let {gridMode = false, endGrid = () => {}}: Props = $props();
+    let {gridMode = false, endGrid = () => {}, search: searchProp}: Props = $props();
 
     function makeAgoText(time:number){
         if(time === 0){
@@ -64,7 +64,7 @@
 </script>
 <div class="flex flex-col items-center w-full overflow-y-auto h-full">
     {#each sortChar(DBState.db.characters) as char, i}
-        {#if char.name.toLocaleLowerCase().includes($MobileSearch.toLocaleLowerCase())}
+        {#if char.name.toLocaleLowerCase().includes(searchProp.toLocaleLowerCase())}
             <button class="flex p-2 border-t-darkborderc gap-2 w-full" class:border-t={i !== 0} onclick={() => {
                 changeChar(char.i)
                 endGrid()

--- a/src/lib/Mobile/MobileFooter.svelte
+++ b/src/lib/Mobile/MobileFooter.svelte
@@ -2,26 +2,26 @@
 
   import { SettingsIcon, GlobeIcon, HouseIcon, Volume2Icon, Braces, ActivityIcon, BookIcon, SmileIcon, UserIcon } from "@lucide/svelte";
   import { language } from "src/lang";
-  import { CharConfigSubMenu, MobileGUIStack, MobileSideBar, selectedCharID } from "src/ts/stores.svelte";
+  import { CharConfigSubMenu, layoutState, selectedCharID } from "src/ts/stores.svelte";
 
 </script>
 {#if $selectedCharID === -1}
 
     <div class="w-full p-4 text-lg border-t border-t-darkborderc bg-darkbg flex items-center justify-center text-textcolor2">
-        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={$MobileGUIStack === 0} onclick={() => {
-            MobileGUIStack.set(0)
+        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={layoutState.betaMobile.stack === 0} onclick={() => {
+            layoutState.betaMobile.stack = 0
         }}>
             <GlobeIcon size={24} />
             <span class="text-xs">RisuRealm</span>
         </button>
-        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={$MobileGUIStack === 1} onclick={() => {
-            MobileGUIStack.set(1)
+        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={layoutState.betaMobile.stack === 1} onclick={() => {
+            layoutState.betaMobile.stack = 1
         }}>
             <HouseIcon size={24} />
             <span class="text-xs">{language.character}</span>
         </button>
-        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={$MobileGUIStack === 2} onclick={() => {
-            MobileGUIStack.set(2)
+        <button class="flex justify-center items-center flex-col gap-2 w-20" class:text-textcolor={layoutState.betaMobile.stack === 2} onclick={() => {
+            layoutState.betaMobile.stack = 2
         }}>
             <SettingsIcon size={24} />
             <span class="text-xs">{language.settings}</span>
@@ -30,7 +30,7 @@
 
 {/if}
 
-{#if $selectedCharID !== -1 && $MobileSideBar === 2}
+{#if $selectedCharID !== -1 && layoutState.betaMobile.sideBar === 2}
     <div class="w-full p-4 text-lg border-t border-t-darkborderc bg-darkbg flex items-center justify-center text-textcolor2 truncate">
         <button class="flex justify-center items-center flex-col gap-2 w-16 max-w-16" class:text-textcolor={$CharConfigSubMenu === 0} onclick={() => {
             CharConfigSubMenu.set(0)

--- a/src/lib/Mobile/MobileHeader.svelte
+++ b/src/lib/Mobile/MobileHeader.svelte
@@ -3,13 +3,14 @@
     import { language } from "src/lang";
     
     import { DBState } from 'src/ts/stores.svelte';
-    import { MobileGUIStack, MobileSearch, selectedCharID, SettingsMenuIndex, MobileSideBar } from "src/ts/stores.svelte";
+    import { layoutState, selectedCharID, SettingsMenuIndex } from "src/ts/stores.svelte";
 
+    let { search = $bindable('') } = $props();
 </script>
 <div class="w-full px-4 h-16 border-b border-b-darkborderc bg-darkbg flex justify-start items-center gap-2">
-    {#if $selectedCharID !== -1 && $MobileSideBar > 0}
+    {#if $selectedCharID !== -1 && layoutState.betaMobile.sideBar > 0}
         <button onclick={() => {
-            MobileSideBar.set(0)
+            layoutState.betaMobile.sideBar = 0
         }}>
             <ArrowLeft />
         </button>
@@ -23,21 +24,21 @@
         <span class="font-bold text-lg w-2/3 truncate">{DBState.db.characters[$selectedCharID].name}</span>
         <div class="flex-1 flex justify-end">
             <button onclick={() => {
-                MobileSideBar.set(1)
+                layoutState.betaMobile.sideBar = 1
             }}>
                 <MenuIcon />
             </button>
         </div>
-    {:else if $MobileGUIStack === 2 && $SettingsMenuIndex > -1}
+    {:else if layoutState.betaMobile.stack === 2 && $SettingsMenuIndex > -1}
         <button onclick={() => {
             SettingsMenuIndex.set(-1)
         }}>
             <ArrowLeft />
         </button>
         <span class="font-bold text-lg">Risuai</span>
-    {:else if $MobileGUIStack === 1}
+    {:else if layoutState.betaMobile.stack === 1}
         <div class="flex items-stretch w-2xl max-w-full">
-            <input placeholder={language.search + '...'} bind:value={$MobileSearch} class="peer focus:border-textcolor transition-colors outline-hidden text-textcolor p-2 min-w-0 border bg-transparent rounded-md input-text text-xl grow mx-4 border-darkborderc resize-none overflow-y-hidden overflow-x-hidden max-w-full">
+            <input placeholder={language.search + '...'} bind:value={search} class="peer focus:border-textcolor transition-colors outline-hidden text-textcolor p-2 min-w-0 border bg-transparent rounded-md input-text text-xl grow mx-4 border-darkborderc resize-none overflow-y-hidden overflow-x-hidden max-w-full">
         </div>
     {:else}
         <span class="font-bold text-lg">Risuai</span>

--- a/src/lib/Others/AlertComp.svelte
+++ b/src/lib/Others/AlertComp.svelte
@@ -2,11 +2,11 @@
     import { alertGenerationInfoStore } from "../../ts/alert";
     
     import { DBState } from 'src/ts/stores.svelte';
-    import { getCharImage } from '../../ts/characters';
+    import { getCharImage } from '../../ts/characters.svelte';
     import { ParseMarkdown } from '../../ts/parser.svelte';
     import BarIcon from '../SideBars/BarIcon.svelte';
     import { ChevronRightIcon, User } from '@lucide/svelte';
-    import { hubURL, isCharacterHasAssets } from 'src/ts/characterCards';
+    import { hubURL, isCharacterHasAssets } from 'src/ts/characterCards.svelte';
     import TextInput from '../UI/GUI/TextInput.svelte';
     import { aiLawApplies, openURL } from 'src/ts/globalApi.svelte';
     import { getFetchLogs } from 'src/ts/fetch';

--- a/src/lib/Others/BookmarkList.svelte
+++ b/src/lib/Others/BookmarkList.svelte
@@ -2,7 +2,7 @@
     import { onMount } from "svelte";
     import { XIcon, TrashIcon, PencilIcon, BookOpenCheckIcon, BookLockIcon, ArrowRightIcon } from "@lucide/svelte";
     import Chat from "../ChatScreens/Chat.svelte";
-    import { getCharImage, findCharacterbyId } from "src/ts/characters";
+    import { getCharImage, findCharacterbyId } from "src/ts/characters.svelte";
     import { getUserName, getUserIcon } from "src/ts/persona"
     import { createSimpleCharacter, modalState, DBState, selectedCharID, ScrollToMessageStore } from "src/ts/stores.svelte";
     import { language } from "src/lang";

--- a/src/lib/Others/BookmarkList.svelte
+++ b/src/lib/Others/BookmarkList.svelte
@@ -4,11 +4,11 @@
     import Chat from "../ChatScreens/Chat.svelte";
     import { getCharImage, findCharacterbyId } from "src/ts/characters";
     import { getUserName, getUserIcon } from "src/ts/persona"
-    import { createSimpleCharacter, bookmarkListOpen, DBState, selectedCharID, ScrollToMessageStore } from "src/ts/stores.svelte";
+    import { createSimpleCharacter, modalState, DBState, selectedCharID, ScrollToMessageStore } from "src/ts/stores.svelte";
     import { language } from "src/lang";
     import { alertInput } from "src/ts/alert";
 
-    const close = () => $bookmarkListOpen = false;
+    const close = () => modalState.bookmark = false;
     let chara = $derived(DBState.db.characters[$selectedCharID]);
     const simpleChar = $derived(createSimpleCharacter(chara));
 

--- a/src/lib/Others/ChatList.svelte
+++ b/src/lib/Others/ChatList.svelte
@@ -5,7 +5,7 @@
     import { DBState } from 'src/ts/stores.svelte';
     import { selectedCharID } from "../../ts/stores.svelte";
     import { DownloadIcon, SquarePenIcon, HardDriveUploadIcon, PlusIcon, TrashIcon, XIcon } from "@lucide/svelte";
-    import { exportChat, importChat, findCharacterbyId } from "../../ts/characters";
+    import { exportChat, importChat, findCharacterbyId } from "../../ts/characters.svelte";
     import TextInput from "../UI/GUI/TextInput.svelte";
     import { changeChatTo } from "src/ts/globalApi.svelte";
 

--- a/src/lib/Others/GridCatalog.svelte
+++ b/src/lib/Others/GridCatalog.svelte
@@ -157,7 +157,7 @@
                 </div>
             {/each}
         {:else if selected === 3}
-            <MobileCharacters gridMode endGrid={endGrid} />
+            <MobileCharacters gridMode endGrid={endGrid} search={search} />
         {/if}
     </div>
 </div>

--- a/src/lib/Others/GridCatalog.svelte
+++ b/src/lib/Others/GridCatalog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { characterFormatUpdate, getCharImage, removeChar } from "../../ts/characters";
+    import { characterFormatUpdate, getCharImage, removeChar } from "../../ts/characters.svelte";
     import type { Database } from "../../ts/storage/types/database";
     import { DBState } from 'src/ts/stores.svelte';
     import BarIcon from "../SideBars/BarIcon.svelte";

--- a/src/lib/Others/HypaV3Modal.svelte
+++ b/src/lib/Others/HypaV3Modal.svelte
@@ -4,9 +4,9 @@
   import { 
     type SerializableSummary, 
     summarize,
-  } from "src/ts/process/memory/hypav3";
+  } from "src/ts/process/memory/hypav3.svelte";
   import { alertNormalWait } from "src/ts/alert";
-  import { DBState, selectedCharID, hypaV3ModalOpen } from "src/ts/stores.svelte";
+  import { DBState, selectedCharID, hypaV3State } from "src/ts/stores.svelte";
   import { language } from "src/lang";
   import { translateHTML } from "src/ts/translator/translator";
   import { alertConfirmTwice } from "./HypaV3Modal/utils";
@@ -115,7 +115,7 @@
   });
 
   $effect(() => {
-    if ($hypaV3ModalOpen) {
+    if (hypaV3State.open) {
       const currentImportantCount = untrack(() => hypaV3Data.summaries.filter(s => s.isImportant).length);
 
       if (currentImportantCount > 0) {

--- a/src/lib/Others/HypaV3Modal/modal-footer.svelte
+++ b/src/lib/Others/HypaV3Modal/modal-footer.svelte
@@ -2,7 +2,7 @@
   import {
     type SerializableHypaV3Data,
     getCurrentHypaV3Preset,
-  } from "src/ts/process/memory/hypav3";
+  } from "src/ts/process/memory/hypav3.svelte";
   import { type Message } from "src/ts/storage/types/chat";
   import { DBState, selectedCharID } from "src/ts/stores.svelte";
   import { language } from "src/lang";

--- a/src/lib/Others/HypaV3Modal/modal-header.svelte
+++ b/src/lib/Others/HypaV3Modal/modal-header.svelte
@@ -13,7 +13,7 @@
   } from "@lucide/svelte";
   import { language } from "src/lang";
   import {
-    hypaV3ModalOpen,
+    hypaV3State,
     settingsOpen,
     SettingsMenuIndex,
   } from "src/ts/stores.svelte";
@@ -77,7 +77,7 @@
   }
 
   function openGlobalSettings() {
-    $hypaV3ModalOpen = false;
+    hypaV3State.open = false;
     $settingsOpen = true;
     $SettingsMenuIndex = 2; // Other bot settings
   }
@@ -98,7 +98,7 @@
   }
 
   function closeModal() {
-    $hypaV3ModalOpen = false;
+    hypaV3State.open = false;
   }
 
   function toggleBulkEditMode() {

--- a/src/lib/Others/HypaV3Modal/modal-summary-item.svelte
+++ b/src/lib/Others/HypaV3Modal/modal-summary-item.svelte
@@ -18,7 +18,7 @@
     type SerializableSummary,
     summarize,
     getCurrentHypaV3Preset,
-  } from "src/ts/process/memory/hypav3";
+  } from "src/ts/process/memory/hypav3.svelte";
   import { type OpenAIChat } from "src/ts/process/index.svelte";
   import { type Message } from "src/ts/storage/types/chat";
   import { translateHTML } from "src/ts/translator/translator";

--- a/src/lib/Others/HypaV3Progress.svelte
+++ b/src/lib/Others/HypaV3Progress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { hypaV3ProgressStore } from "src/ts/stores.svelte";
+  import { hypaV3State } from "src/ts/stores.svelte";
 
   let isExpanded = $state(false);
 
@@ -18,7 +18,7 @@
       onclick={toggleExpand}
     >
       <span class="mb-6 text-left text-gray-500 text-sm"
-        >{$hypaV3ProgressStore.msg || ""}</span
+        >{hypaV3State.progress.msg || ""}</span
       >
       <div
         class="w-full min-w-64 md:min-w-138 h-2 bg-darkbg border border-darkborderc rounded-md"
@@ -28,7 +28,7 @@
         ></div>
       </div>
       <span class="w-full mt-6 text-center text-gray-500 text-sm"
-        >{$hypaV3ProgressStore.subMsg || ""}</span
+        >{hypaV3State.progress.subMsg || ""}</span
       >
     </button>
   </div>
@@ -48,7 +48,7 @@
       <div
         class="absolute inset-1 flex items-center justify-center text-xs text-gray-300"
       >
-        {$hypaV3ProgressStore.miniMsg || ""}
+        {hypaV3State.progress.miniMsg || ""}
       </div>
     </div>
   </button>

--- a/src/lib/Playground/PlaygroundImageGen.svelte
+++ b/src/lib/Playground/PlaygroundImageGen.svelte
@@ -3,7 +3,7 @@
     import TextAreaInput from "../UI/GUI/TextAreaInput.svelte";
     import Button from "../UI/GUI/Button.svelte";
     import { generateAIImage } from "src/ts/process/stableDiff";
-    import { createBlankChar } from "src/ts/characters";
+    import { createBlankChar } from "src/ts/characters.svelte";
     let prompt = $state("");
     let negPrompt = $state("");
     let img = $state("");

--- a/src/lib/Playground/PlaygroundMenu.svelte
+++ b/src/lib/Playground/PlaygroundMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { ArrowLeft } from "@lucide/svelte";
     import { language } from "src/lang";
-    import { PlaygroundStore, SizeState, selectedCharID } from "src/ts/stores.svelte";
+    import { PlaygroundStore, layoutState, selectedCharID } from "src/ts/stores.svelte";
     import PlaygroundEmbedding from "./PlaygroundEmbedding.svelte";
     import PlaygroundTokenizer from "./PlaygroundTokenizer.svelte";
     import PlaygroundJinja from "./PlaygroundJinja.svelte";
@@ -137,7 +137,7 @@
             </button>
         </div>
     {:else}
-        {#if SizeState.w < 1024}
+        {#if layoutState.compactMode}
             <div class="mt-14"></div>
         {/if}
         <div class="w-full max-w-4xl flex flex-col p-2">

--- a/src/lib/Playground/PlaygroundMenu.svelte
+++ b/src/lib/Playground/PlaygroundMenu.svelte
@@ -6,7 +6,7 @@
     import PlaygroundTokenizer from "./PlaygroundTokenizer.svelte";
     import PlaygroundJinja from "./PlaygroundJinja.svelte";
     import PlaygroundSyntax from "./PlaygroundSyntax.svelte";
-    import { characterFormatUpdate, createBlankChar, findCharacterIndexbyId } from "src/ts/characters";
+    import { characterFormatUpdate, createBlankChar, findCharacterIndexbyId } from "src/ts/characters.svelte";
     import type { character } from "src/ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
     import PlaygroundImageGen from "./PlaygroundImageGen.svelte";

--- a/src/lib/Playground/PlaygroundMenu.svelte
+++ b/src/lib/Playground/PlaygroundMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { ArrowLeft } from "@lucide/svelte";
     import { language } from "src/lang";
-    import { PlaygroundStore, SizeStore, selectedCharID } from "src/ts/stores.svelte";
+    import { PlaygroundStore, SizeState, selectedCharID } from "src/ts/stores.svelte";
     import PlaygroundEmbedding from "./PlaygroundEmbedding.svelte";
     import PlaygroundTokenizer from "./PlaygroundTokenizer.svelte";
     import PlaygroundJinja from "./PlaygroundJinja.svelte";
@@ -137,7 +137,7 @@
             </button>
         </div>
     {:else}
-        {#if $SizeStore.w < 1024}
+        {#if SizeState.w < 1024}
             <div class="mt-14"></div>
         {/if}
         <div class="w-full max-w-4xl flex flex-col p-2">

--- a/src/lib/Setting/Pages/BotSettings.svelte
+++ b/src/lib/Setting/Pages/BotSettings.svelte
@@ -25,7 +25,7 @@
     import OpenrouterSettings from "./OpenrouterSettings.svelte";
     import ChatFormatSettings from "./ChatFormatSettings.svelte";
     import PromptSettings from "./PromptSettings.svelte";
-    import { openPresetList } from "src/ts/stores.svelte";
+    import { modalState } from "src/ts/stores.svelte";
     import { selectSingleFile } from "src/ts/util";
   import { getModelInfo, LLMFlags, LLMFormat, LLMProvider } from "src/ts/model/modellist";
   import RegexList from "src/lib/SideBars/Scripts/RegexList.svelte";
@@ -676,7 +676,7 @@ let tokens = $state({
         </button>
     </Accordion>
     {#if submenu !== -1}
-        <Button onclick={() => {$openPresetList = true}} className="mt-4">{language.presets}</Button>
+        <Button onclick={() => {modalState.preset = true}} className="mt-4">{language.presets}</Button>
     {/if}
 {/if}
 
@@ -708,5 +708,5 @@ let tokens = $state({
     </div>
 {/if}
 {#if submenu === -1}
-    <Button onclick={() => {$openPresetList = true}} className="mt-4">{language.presets}</Button>
+    <Button onclick={() => {modalState.preset = true}} className="mt-4">{language.presets}</Button>
 {/if}

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -11,7 +11,7 @@
     import SelectInput from "src/lib/UI/GUI/SelectInput.svelte";
     import OptionInput from "src/lib/UI/GUI/OptionInput.svelte";
     import SliderInput from "src/lib/UI/GUI/SliderInput.svelte";
-    import { getCharImage } from "src/ts/characters";
+    import { getCharImage } from "src/ts/characters.svelte";
     import Accordion from "src/lib/UI/Accordion.svelte";
     import CheckInput from "src/lib/UI/GUI/CheckInput.svelte";
     import TextAreaInput from "src/lib/UI/GUI/TextAreaInput.svelte";

--- a/src/lib/Setting/Pages/OtherBotSettings.svelte
+++ b/src/lib/Setting/Pages/OtherBotSettings.svelte
@@ -20,7 +20,7 @@
     import { getCharToken } from "src/ts/tokenizer";
     import { PlusIcon, PencilIcon, TrashIcon, DownloadIcon, HardDriveUploadIcon } from "@lucide/svelte";
     import { alertError, alertInput, alertConfirm, alertNormal } from "src/ts/alert";
-    import { createHypaV3Preset } from "src/ts/process/memory/hypav3";
+    import { createHypaV3Preset } from "src/ts/process/memory/hypav3.svelte";
 
     let submenu = $state(DBState.db.useLegacyGUI ? -1 : 0);
 

--- a/src/lib/Setting/Pages/PersonaSettings.svelte
+++ b/src/lib/Setting/Pages/PersonaSettings.svelte
@@ -6,7 +6,7 @@
     import TextAreaInput from "src/lib/UI/GUI/TextAreaInput.svelte";
     import TextInput from "src/lib/UI/GUI/TextInput.svelte";
     import { alertConfirm, alertSelect } from "src/ts/alert";
-    import { getCharImage } from "src/ts/characters";
+    import { getCharImage } from "src/ts/characters.svelte";
     import { changeUserPersona, exportUserPersona, importUserPersona, saveUserPersona, selectUserImg } from "src/ts/persona";
     import Sortable from 'sortablejs/modular/sortable.core.esm.js';
     import { onDestroy, onMount } from "svelte";

--- a/src/lib/Setting/Pages/UserSettings.svelte
+++ b/src/lib/Setting/Pages/UserSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { language } from "src/lang";
-    import { hubURL } from "src/ts/characterCards";
+    import { hubURL } from "src/ts/characterCards.svelte";
     import { loadRisuAccountBackup, loadRisuAccountData, saveRisuAccountData } from "src/ts/drive/accounter";
     
     import { DBState } from 'src/ts/stores.svelte';

--- a/src/lib/Setting/Settings.svelte
+++ b/src/lib/Setting/Settings.svelte
@@ -8,7 +8,7 @@
     import PluginSettings from "./Pages/PluginSettings.svelte";
     import FilesSettings from "./Pages/FilesSettings.svelte";
     import AdvancedSettings from "./Pages/AdvancedSettings.svelte";
-    import { additionalSettingsMenu, MobileGUI, SettingsMenuIndex, settingsOpen } from "src/ts/stores.svelte";
+    import { additionalSettingsMenu, layoutState, SettingsMenuIndex, settingsOpen } from "src/ts/stores.svelte";
     import { DBState } from "src/ts/stores.svelte";
     import Communities from "./Pages/Communities.svelte";
     import GlobalLoreBookSettings from "./Pages/GlobalLoreBookSettings.svelte";
@@ -25,17 +25,17 @@
     import PluginDefinedIcon from "../Others/PluginDefinedIcon.svelte";
 
     let openLoreList = $state(false)
-    if(window.innerWidth >= 900 && $SettingsMenuIndex === -1 && !$MobileGUI){
+    if(window.innerWidth >= 900 && $SettingsMenuIndex === -1 && !layoutState.betaMobile.enabled){
         $SettingsMenuIndex = 1
     }
 
 </script>
-<div class="h-full w-full flex justify-center rs-setting-cont" class:bg-bgcolor={$MobileGUI} class:setting-bg={!$MobileGUI}>
+<div class="h-full w-full flex justify-center rs-setting-cont" class:bg-bgcolor={layoutState.betaMobile.enabled} class:setting-bg={!layoutState.betaMobile.enabled}>
     <div class="h-full max-w-(--breakpoint-lg) w-full flex relative rs-setting-cont-2">
-        {#if (window.innerWidth >= 700 && !$MobileGUI) || $SettingsMenuIndex === -1}
+        {#if (window.innerWidth >= 700 && !layoutState.betaMobile.enabled) || $SettingsMenuIndex === -1}
             <div class="flex h-full flex-col p-4 pt-8 gap-2 overflow-y-auto relative rs-setting-cont-3 shrink-0"
-                class:w-full={window.innerWidth < 700 || $MobileGUI}
-                class:bg-darkbg={!$MobileGUI} class:bg-bgcolor={$MobileGUI}
+                class:w-full={window.innerWidth < 700 || layoutState.betaMobile.enabled}
+                class:bg-darkbg={!layoutState.betaMobile.enabled} class:bg-bgcolor={layoutState.betaMobile.enabled}
             >
                 
                 {#if !$isLite}
@@ -162,14 +162,14 @@
                         </button>
                     {/each}
                 {/if}
-                {#if window.innerWidth < 700 && !$MobileGUI}
+                {#if window.innerWidth < 700 && !layoutState.betaMobile.enabled}
                     <button class="absolute top-2 right-2 hover:text-green-500 text-textcolor" onclick={() => {
                         settingsOpen.set(false)
                     }}> <CircleXIcon size={DBState.db.settingsCloseButtonSize} /> </button>
                 {/if}
             </div>
         {/if}
-        {#if (window.innerWidth >= 700 && !$MobileGUI) || $SettingsMenuIndex !== -1}
+        {#if (window.innerWidth >= 700 && !layoutState.betaMobile.enabled) || $SettingsMenuIndex !== -1}
             {#key $SettingsMenuIndex}
                 <div class="grow py-6 px-4 bg-bgcolor flex flex-col text-textcolor overflow-y-auto relative rs-setting-cont-4 min-w-0">
                     {#if $SettingsMenuIndex === 0}
@@ -213,7 +213,7 @@
                     {/if}
             </div>
             {/key}
-            {#if !$MobileGUI}
+            {#if !layoutState.betaMobile.enabled}
                 <button class="absolute top-2 right-2 hover:text-green-500 text-textcolor" onclick={() => {
                     if(window.innerWidth >= 700){
                         settingsOpen.set(false)

--- a/src/lib/Setting/botpreset.svelte
+++ b/src/lib/Setting/botpreset.svelte
@@ -6,7 +6,7 @@
     import { CopyIcon, Share2Icon, PencilIcon, HardDriveUploadIcon, PlusIcon, TrashIcon, XIcon, GitCompare } from "@lucide/svelte";
     import TextInput from "../UI/GUI/TextInput.svelte";
     import { prebuiltPresets } from "src/ts/process/templates/templates";
-    import { ShowRealmFrameStore } from "src/ts/stores.svelte";
+    import { realmState } from "src/ts/stores.svelte";
     import PromptDiffModal from "../Others/PromptDiffModal.svelte";
 
     let editMode = $state(false)
@@ -211,7 +211,7 @@
                             downloadPreset(i, 'risupreset')
                         }
                         if(data.type === 'realm'){
-                            $ShowRealmFrameStore = `preset:${i}`
+                            realmState.uploadTarget = `preset:${i}`
                         }
                     }} onkeydown={(e) => {
                         if(e.key === 'Enter' && e.currentTarget instanceof HTMLElement){

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -4,7 +4,7 @@
     import { saveImage as saveAsset } from "../../ts/storage/database.svelte";
     import type { character, groupChat } from "../../ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
-    import { CharConfigSubMenu, MobileGUI, realmState, selectedCharID, hypaV3State } from "../../ts/stores.svelte";
+    import { CharConfigSubMenu, layoutState, realmState, selectedCharID, hypaV3State } from "../../ts/stores.svelte";
     import { PlusIcon, SmileIcon, TrashIcon, UserIcon, ActivityIcon, BookIcon, User, Braces, Volume2Icon, DownloadIcon, HardDriveUploadIcon, Share2Icon, ImageIcon, ImageOffIcon, ArrowUp, ArrowDown } from '@lucide/svelte'
     import Check from "../UI/GUI/CheckInput.svelte";
     import { addCharEmotion, addingEmotion, getCharImage, rmCharEmotion, selectCharImg, makeGroupImage, removeChar, changeCharImage } from "../../ts/characters.svelte";
@@ -216,7 +216,7 @@
 
 </script>
 
-{#if licensed !== 'private' && !$MobileGUI}
+{#if licensed !== 'private' && !layoutState.betaMobile.enabled}
     <div class="flex mb-2" class:gap-2={iconButtonSize === 24} class:gap-1={iconButtonSize < 24}>
         <button class={$CharConfigSubMenu === 0 ? 'text-textcolor ' : 'text-textcolor2'} onclick={() => {$CharConfigSubMenu = 0}}>
             <UserIcon size={iconButtonSize} />
@@ -318,7 +318,7 @@
     />
     <span class="text-textcolor2 mb-6 text-sm">{tokens.localNote} {language.tokens}</span>
 
-    {#if !$MobileGUI}
+    {#if !layoutState.betaMobile.enabled}
         <Toggles bind:chara={DBState.db.characters[$selectedCharID]} noContainer />
 
         {#if DBState.db.characters[$selectedCharID].type === 'group'}
@@ -333,7 +333,7 @@
         $CharConfigSubMenu = 0
     })()}
 {:else if $CharConfigSubMenu === 1}
-    {#if !$MobileGUI}
+    {#if !layoutState.betaMobile.enabled}
         <h2 class="mb-2 text-2xl font-bold mt-2">{language.characterDisplay}</h2>
     {/if}
 
@@ -659,13 +659,13 @@
             </div>
     {/if}
 {:else if $CharConfigSubMenu === 3}
-    {#if !$MobileGUI}
+    {#if !layoutState.betaMobile.enabled}
         <h2 class="mb-2 text-2xl font-bold mt-2">{language.loreBook} <Help key="lorebook"/></h2>
     {/if}
     <LoreBook />
 {:else if $CharConfigSubMenu === 4}
     {#if DBState.db.characters[$selectedCharID].type === 'character'}
-        {#if !$MobileGUI}
+        {#if !layoutState.betaMobile.enabled}
             <h2 class="mb-2 text-2xl font-bold mt-2">{language.scripts}</h2>
         {/if}
 
@@ -739,7 +739,7 @@
     
 {:else if $CharConfigSubMenu === 5}
     {#if DBState.db.characters[$selectedCharID].type === 'character'}
-        {#if !$MobileGUI}
+        {#if !layoutState.betaMobile.enabled}
             <h2 class="mb-2 text-2xl font-bold mt-2">TTS</h2>
         {/if}
         <span class="text-textcolor">{language.provider}</span>
@@ -1002,7 +1002,7 @@
         {/if}
     {/if}
 {:else if $CharConfigSubMenu === 2}
-    {#if !$MobileGUI}
+    {#if !layoutState.betaMobile.enabled}
         <h2 class="mb-2 text-2xl font-bold mt-2">{language.advancedSettings}</h2>
     {/if}
         {#if DBState.db.characters[$selectedCharID].type !== 'group'}

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -4,18 +4,18 @@
     import { saveImage as saveAsset } from "../../ts/storage/database.svelte";
     import type { character, groupChat } from "../../ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
-    import { CharConfigSubMenu, MobileGUI, ShowRealmFrameStore, selectedCharID, hypaV3State } from "../../ts/stores.svelte";
+    import { CharConfigSubMenu, MobileGUI, realmState, selectedCharID, hypaV3State } from "../../ts/stores.svelte";
     import { PlusIcon, SmileIcon, TrashIcon, UserIcon, ActivityIcon, BookIcon, User, Braces, Volume2Icon, DownloadIcon, HardDriveUploadIcon, Share2Icon, ImageIcon, ImageOffIcon, ArrowUp, ArrowDown } from '@lucide/svelte'
     import Check from "../UI/GUI/CheckInput.svelte";
-    import { addCharEmotion, addingEmotion, getCharImage, rmCharEmotion, selectCharImg, makeGroupImage, removeChar, changeCharImage } from "../../ts/characters";
+    import { addCharEmotion, addingEmotion, getCharImage, rmCharEmotion, selectCharImg, makeGroupImage, removeChar, changeCharImage } from "../../ts/characters.svelte";
     import LoreBook from "./LoreBook/LoreBookSetting.svelte";
     import { alertTOS, showHypaV2Alert } from "../../ts/alert";
     import BarIcon from "./BarIcon.svelte";
     import { selectMultipleFile, selectSingleFile } from "../../ts/util";
     import { getAuthorNoteDefaultText } from "src/ts/process/prompt"
-    import { findCharacterbyId } from "../../ts/characters";
+    import { findCharacterbyId } from "../../ts/characters.svelte";
     import Help from "../Others/Help.svelte";
-    import { exportChar } from "src/ts/characterCards";
+    import { exportChar } from "src/ts/characterCards.svelte";
     import { getElevenTTSVoices, getWebSpeechTTSVoices, getVOICEVOXVoices, oaiVoices, getNovelAIVoices } from "src/ts/process/tts";
     import { getFileSrc } from "src/ts/globalApi.svelte";
     import { addGroupChar, rmCharFromGroup } from "src/ts/process/group";
@@ -711,7 +711,7 @@
     }
         <Button size="lg" onclick={async () => {
             if(await alertTOS()){
-                $ShowRealmFrameStore = 'character'
+                realmState.uploadTarget = 'character'
             }
         }} className="mt-2">
             {#if DBState.db.characters[$selectedCharID].realmId}

--- a/src/lib/SideBars/CharConfig.svelte
+++ b/src/lib/SideBars/CharConfig.svelte
@@ -4,7 +4,7 @@
     import { saveImage as saveAsset } from "../../ts/storage/database.svelte";
     import type { character, groupChat } from "../../ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
-    import { CharConfigSubMenu, MobileGUI, ShowRealmFrameStore, selectedCharID, hypaV3ModalOpen } from "../../ts/stores.svelte";
+    import { CharConfigSubMenu, MobileGUI, ShowRealmFrameStore, selectedCharID, hypaV3State } from "../../ts/stores.svelte";
     import { PlusIcon, SmileIcon, TrashIcon, UserIcon, ActivityIcon, BookIcon, User, Braces, Volume2Icon, DownloadIcon, HardDriveUploadIcon, Share2Icon, ImageIcon, ImageOffIcon, ArrowUp, ArrowDown } from '@lucide/svelte'
     import Check from "../UI/GUI/CheckInput.svelte";
     import { addCharEmotion, addingEmotion, getCharImage, rmCharEmotion, selectCharImg, makeGroupImage, removeChar, changeCharImage } from "../../ts/characters";
@@ -1186,7 +1186,7 @@
         {:else if DBState.db.hypaV3}
             <Button
                 onclick={() => {
-                    $hypaV3ModalOpen = true
+                    hypaV3State.open = true
                 }}
                 className="mt-4"
             >

--- a/src/lib/SideBars/Scripts/TriggerList.svelte
+++ b/src/lib/SideBars/Scripts/TriggerList.svelte
@@ -10,7 +10,7 @@
     import TextAreaInput from "src/lib/UI/GUI/TextAreaInput.svelte";
     import Button from "src/lib/UI/GUI/Button.svelte";
     import { openURL } from "src/ts/globalApi.svelte";
-    import { hubURL } from "src/ts/characterCards";
+    import { hubURL } from "src/ts/characterCards.svelte";
     import { PlusIcon } from "@lucide/svelte";
     import TriggerV2List from "./TriggerList2.svelte";
     import { DBState } from "src/ts/stores.svelte";

--- a/src/lib/SideBars/SideChatList.svelte
+++ b/src/lib/SideBars/SideChatList.svelte
@@ -18,7 +18,7 @@
     import { sleep, sortableOptions } from "src/ts/util";
     import { findCharacterbyId } from "src/ts/characters";
     import { createMultiuserRoom } from "src/ts/sync/multiuser";
-    import { bookmarkListOpen } from "src/ts/stores.svelte";
+    import { modalState } from "src/ts/stores.svelte";
     import { language } from "src/lang";
     import Toggles from "./Toggles.svelte";
     import { changeChatTo } from "src/ts/globalApi.svelte";
@@ -489,7 +489,7 @@
                 <SplitIcon size={18}/>
             </button>
             <button class="text-textcolor2 hover:text-green-500 mr-2 cursor-pointer" onclick={() => {
-                $bookmarkListOpen = true;
+                modalState.bookmark = true;
             }}>
                 <BookmarkCheckIcon size={18}/>
             </button>

--- a/src/lib/SideBars/SideChatList.svelte
+++ b/src/lib/SideBars/SideChatList.svelte
@@ -13,10 +13,10 @@
     import Button from "../UI/GUI/Button.svelte";
     import TextInput from "../UI/GUI/TextInput.svelte";
 
-    import { exportChat, importChat, exportAllChats } from "src/ts/characters";
+    import { exportChat, importChat, exportAllChats } from "src/ts/characters.svelte";
     import { alertChatOptions, alertConfirm, alertError, alertNormal, alertSelect, alertStore } from "src/ts/alert";
     import { sleep, sortableOptions } from "src/ts/util";
-    import { findCharacterbyId } from "src/ts/characters";
+    import { findCharacterbyId } from "src/ts/characters.svelte";
     import { createMultiuserRoom } from "src/ts/sync/multiuser";
     import { modalState } from "src/ts/stores.svelte";
     import { language } from "src/lang";

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -6,7 +6,7 @@
     selectedCharID,
     settingsOpen,
     sideBarState,
-    OpenRealmStore,
+    realmState,
     PlaygroundStore,
 
     QuickSettings
@@ -32,14 +32,14 @@
   addCharacter,
     changeChar,
     getCharImage,
-  } from "../../ts/characters";
+  } from "../../ts/characters.svelte";
     import CharConfig from "./CharConfig.svelte";
     import { language } from "../../lang";
     import { isEqual } from "lodash";
     import SidebarAvatar from "./SidebarAvatar.svelte";
     import BaseRoundedButton from "../UI/BaseRoundedButton.svelte";
     import { selectSingleFile } from "src/ts/util";
-    import { getCharacterIndexObject } from "src/ts/characters";
+    import { getCharacterIndexObject } from "src/ts/characters.svelte";
     import { v4 } from "uuid";
     import { checkCharOrder, getFileSrc, saveAsset } from "src/ts/globalApi.svelte";
     import { alertInput, alertSelect } from "src/ts/alert";
@@ -318,7 +318,7 @@
     reseter();
     selectedCharID.set(-1)
     PlaygroundStore.set(0)
-    OpenRealmStore.set(false)
+    realmState.expanded = false
   }}
 >
   <HomeIcon />
@@ -405,7 +405,7 @@
           reseter();
           selectedCharID.set(-1)
           PlaygroundStore.set(0)
-          OpenRealmStore.set(false)
+          realmState.expanded = false
         }}><HomeIcon /></BarIcon>
       <div class="mt-2"></div>
       <BarIcon

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import {
     CharEmotion,
-    DynamicGUI,
+    layoutState,
     botMakerMode,
     selectedCharID,
     settingsOpen,
@@ -685,13 +685,13 @@
   class:w-124={$sideBarSize === 2}
   class:w-138={$sideBarSize === 3}
   class:risu-sidebar-close={sideBarState.closing}
-  class:min-w-96={!$DynamicGUI && $sideBarSize === 0}
-  class:min-w-110={!$DynamicGUI && $sideBarSize === 1}
-  class:min-w-124={!$DynamicGUI && $sideBarSize === 2}
-  class:min-w-138={!$DynamicGUI && $sideBarSize === 3}
-  class:px-2={$DynamicGUI}
-  class:px-4={!$DynamicGUI}
-  class:dynamic-sidebar={$DynamicGUI}
+  class:min-w-96={!layoutState.compactMode && $sideBarSize === 0}
+  class:min-w-110={!layoutState.compactMode && $sideBarSize === 1}
+  class:min-w-124={!layoutState.compactMode && $sideBarSize === 2}
+  class:min-w-138={!layoutState.compactMode && $sideBarSize === 3}
+  class:px-2={layoutState.compactMode}
+  class:px-4={!layoutState.compactMode}
+  class:dynamic-sidebar={layoutState.compactMode}
   class:hidden={hidden}
   class:flex={!hidden}
   onanimationend={() => {
@@ -767,7 +767,7 @@
   {/if}
 </div>
 
-{#if $DynamicGUI}
+{#if layoutState.compactMode}
     <div role="button" tabindex="0" class="grow h-full min-w-12" class:hidden={hidden} onclick={() => {
       if(sideBarState.closing){
         return

--- a/src/lib/SideBars/Sidebar.svelte
+++ b/src/lib/SideBars/Sidebar.svelte
@@ -5,8 +5,7 @@
     botMakerMode,
     selectedCharID,
     settingsOpen,
-    sideBarClosing,
-    sideBarStore,
+    sideBarState,
     OpenRealmStore,
     PlaygroundStore,
 
@@ -75,7 +74,7 @@
 
   let { openGrid = () => {}, hidden = false }: Props = $props();
 
-  sideBarClosing.set(false)
+  sideBarState.closing = false
 
   $effect(() => {
     let newCharImages: sortType[] = [];
@@ -303,8 +302,8 @@
 <div
   class="h-full w-20 min-w-20 flex-col items-center bg-bgcolor text-textcolor shadow-lg relative rs-sidebar"
   class:editMode
-  class:risu-sub-sidebar={$sideBarClosing}
-  class:risu-sub-sidebar-close={$sideBarClosing}
+  class:risu-sub-sidebar={sideBarState.closing}
+  class:risu-sub-sidebar-close={sideBarState.closing}
   class:hidden={hidden}
   class:flex={!hidden}
 >
@@ -375,8 +374,8 @@
 <div
   class="h-full w-20 min-w-20 flex-col items-center bg-bgcolor text-textcolor shadow-lg relative rs-sidebar"
   class:editMode
-  class:risu-sub-sidebar={$sideBarClosing}
-  class:risu-sub-sidebar-close={$sideBarClosing}
+  class:risu-sub-sidebar={sideBarState.closing}
+  class:risu-sub-sidebar-close={sideBarState.closing}
   class:hidden={hidden}
   class:flex={!hidden}
 >
@@ -680,12 +679,12 @@
 {/if}
 <div
   class="setting-area h-full flex-col overflow-y-auto overflow-x-hidden bg-darkbg py-6 text-textcolor max-h-full"
-  class:risu-sidebar={!$sideBarClosing}
+  class:risu-sidebar={!sideBarState.closing}
   class:w-96={$sideBarSize === 0}
   class:w-110={$sideBarSize === 1}
   class:w-124={$sideBarSize === 2}
   class:w-138={$sideBarSize === 3}
-  class:risu-sidebar-close={$sideBarClosing}
+  class:risu-sidebar-close={sideBarState.closing}
   class:min-w-96={!$DynamicGUI && $sideBarSize === 0}
   class:min-w-110={!$DynamicGUI && $sideBarSize === 1}
   class:min-w-124={!$DynamicGUI && $sideBarSize === 2}
@@ -696,19 +695,19 @@
   class:hidden={hidden}
   class:flex={!hidden}
   onanimationend={() => {
-    if($sideBarClosing){
-      $sideBarClosing = false
-      sideBarStore.set(false)
+    if(sideBarState.closing){
+      sideBarState.closing = false
+      sideBarState.open = false;
     }
   }}
 >
   <button
     class="flex w-full justify-end text-textcolor"
     onclick={async () => {
-      if($sideBarClosing){
+      if(sideBarState.closing){
         return
       }
-      $sideBarClosing = true;
+      sideBarState.closing = true;
     }}
   >
     <!-- <button class="border-none bg-transparent p-0 text-textcolor"><X /></button> -->
@@ -770,18 +769,18 @@
 
 {#if $DynamicGUI}
     <div role="button" tabindex="0" class="grow h-full min-w-12" class:hidden={hidden} onclick={() => {
-      if($sideBarClosing){
+      if(sideBarState.closing){
         return
       }
-      $sideBarClosing = true;
+      sideBarState.closing = true;
     }}
       onkeydown={(e)=>{
         if(e.key === 'Enter'){
             e.currentTarget.click()
         }
       }}
-      class:sidebar-dark-animation={!$sideBarClosing}
-      class:sidebar-dark-close-animation={$sideBarClosing}>
+      class:sidebar-dark-animation={!sideBarState.closing}
+      class:sidebar-dark-close-animation={sideBarState.closing}>
 
     </div>
 

--- a/src/lib/SideBars/Toggles.svelte
+++ b/src/lib/SideBars/Toggles.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { getModuleToggles } from "src/ts/process/modules";
-    import { DBState, MobileGUI } from "src/ts/stores.svelte";
+    import { DBState, layoutState } from "src/ts/stores.svelte";
     import { parseToggleSyntax, type sidebarToggle, type sidebarToggleGroup } from "src/ts/util";
     import { language } from "src/lang";
     import type { PromptItem } from "src/ts/process/prompt";
@@ -79,7 +79,7 @@
                 </Accordion>
             </div>
         {:else if toggle.type === 'select'}
-            <div class="w-full flex gap-2 mt-2 items-center" class:justify-end={$MobileGUI} >
+            <div class="w-full flex gap-2 mt-2 items-center" class:justify-end={layoutState.betaMobile.enabled} >
                 <span>{toggle.value}</span>
                 <SelectInput className="w-32" bind:value={DBState.db.globalChatVariables[`toggle_${toggle.key}`]}>
                     {#each toggle.options as option, i}
@@ -88,7 +88,7 @@
                 </SelectInput>
             </div>
         {:else if toggle.type === 'text'}
-            <div class="w-full flex gap-2 mt-2 items-center" class:justify-end={$MobileGUI}>
+            <div class="w-full flex gap-2 mt-2 items-center" class:justify-end={layoutState.betaMobile.enabled}>
                 <span>{toggle.value}</span>
                 <TextInput className="w-32" bind:value={DBState.db.globalChatVariables[`toggle_${toggle.key}`]} />
             </div>
@@ -103,7 +103,7 @@
                 </div>
             {/if}
         {:else}
-            <div class="w-full flex mt-2 items-center" class:justify-end={$MobileGUI}>
+            <div class="w-full flex mt-2 items-center" class:justify-end={layoutState.betaMobile.enabled}>
                 <CheckInput check={DBState.db.globalChatVariables[`toggle_${toggle.key}`] === '1'} reverse={reverse} name={toggle.value} onChange={() => {
                     DBState.db.globalChatVariables[`toggle_${toggle.key}`] = DBState.db.globalChatVariables[`toggle_${toggle.key}`] === '1' ? '0' : '1'
                 }} />
@@ -115,13 +115,13 @@
 {#if !noContainer && groupedToggles.length > 4}
     <div class="h-48 border-darkborderc p-2 border rounded-sm flex flex-col items-start mt-2 overflow-y-auto">
         {#if hasJailbreakPrompt}
-            <div class="flex mt-2 items-center w-full" class:justify-end={$MobileGUI}>
+            <div class="flex mt-2 items-center w-full" class:justify-end={layoutState.betaMobile.enabled}>
                 <CheckInput bind:check={DBState.db.jailbreakToggle} name={language.jailbreakToggle} reverse />
             </div>
         {/if}
         {@render toggles(groupedToggles, true)}
         {#if DBState.db.supaModelType !== 'none' || DBState.db.hanuraiEnable || DBState.db.hypaV3}
-            <div class="flex mt-2 items-center w-full" class:justify-end={$MobileGUI}>
+            <div class="flex mt-2 items-center w-full" class:justify-end={layoutState.betaMobile.enabled}>
                 <CheckInput bind:check={chara.supaMemory} reverse name={DBState.db.hypaV3 ? language.ToggleHypaMemory : DBState.db.hanuraiEnable ? language.hanuraiMemory : DBState.db.hypaMemory ? language.ToggleHypaMemory : language.ToggleSuperMemory}/>
             </div>
         {/if}

--- a/src/lib/UI/GUI/SideBarArrow.svelte
+++ b/src/lib/UI/GUI/SideBarArrow.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import { ArrowLeft, ArrowRight } from "@lucide/svelte";
-    import { layoutState, MobileGUI, sideBarState } from "src/ts/stores.svelte";
+    import { layoutState, sideBarState } from "src/ts/stores.svelte";
 
 </script>
 
-{#if !$MobileGUI}
+{#if !layoutState.betaMobile.enabled}
     {#if sideBarState.open && !layoutState.compactMode}
         <button onclick={() => {sideBarState.closing = true}} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-transparent  rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor z-20">
             <ArrowLeft />

--- a/src/lib/UI/GUI/SideBarArrow.svelte
+++ b/src/lib/UI/GUI/SideBarArrow.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
     import { ArrowLeft, ArrowRight } from "@lucide/svelte";
-    import { DynamicGUI, MobileGUI, sideBarClosing, sideBarStore } from "src/ts/stores.svelte";
+    import { DynamicGUI, MobileGUI, sideBarState } from "src/ts/stores.svelte";
 
 </script>
 
 {#if !$MobileGUI}
-    {#if $sideBarStore && !$DynamicGUI}
-        <button onclick={() => {sideBarClosing.set(true)}} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-transparent  rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor z-20">
+    {#if sideBarState.open && !$DynamicGUI}
+        <button onclick={() => {sideBarState.closing = true}} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-transparent  rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor z-20">
             <ArrowLeft />
         </button>
     {:else}
         <button onclick={() => {
-            sideBarClosing.set(false);
-            sideBarStore.set(true)}} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-borderc rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor opacity-50 hover:opacity-90 z-20">
+            sideBarState.closing = false
+            sideBarState.open = true
+            }} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-borderc rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor opacity-50 hover:opacity-90 z-20">
             <ArrowRight />
         </button>
     {/if}

--- a/src/lib/UI/GUI/SideBarArrow.svelte
+++ b/src/lib/UI/GUI/SideBarArrow.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import { ArrowLeft, ArrowRight } from "@lucide/svelte";
-    import { DynamicGUI, MobileGUI, sideBarState } from "src/ts/stores.svelte";
+    import { layoutState, MobileGUI, sideBarState } from "src/ts/stores.svelte";
 
 </script>
 
 {#if !$MobileGUI}
-    {#if sideBarState.open && !$DynamicGUI}
+    {#if sideBarState.open && !layoutState.compactMode}
         <button onclick={() => {sideBarState.closing = true}} class="absolute top-3 left-0 h-12 w-12 border-r border-b border-t border-transparent  rounded-r-md bg-darkbg hover:border-neutral-200 transition-colors flex items-center justify-center text-textcolor z-20">
             <ArrowLeft />
         </button>

--- a/src/lib/UI/MainMenu.svelte
+++ b/src/lib/UI/MainMenu.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
     import { DBState } from 'src/ts/stores.svelte';
     import Hub from "./Realm/RealmMain.svelte";
-    import { OpenRealmStore, RealmInitialOpenChar } from "src/ts/stores.svelte";
+    import { realmState } from "src/ts/stores.svelte";
     import { ArrowLeft } from "@lucide/svelte";
     import { getVersionString, openURL } from "src/ts/globalApi.svelte";
     import { language } from "src/lang";
-    import { getRisuHub, hubAdditionalHTML } from "src/ts/characterCards";
+    import { getRisuHub, hubAdditionalHTML } from "src/ts/characterCards.svelte";
     import RisuHubIcon from "./Realm/RealmHubIcon.svelte";
     import Title from "./Title.svelte";
 </script>
 <div class="h-full w-full flex flex-col overflow-y-auto items-center">
-    {#if !$OpenRealmStore}
+    {#if !realmState.expanded}
       <Title />
       <h3 class="text-textcolor2 mt-1">Version {getVersionString()}</h3>
     {/if}
     <div class="w-full flex p-4 flex-col text-textcolor max-w-4xl">
-      {#if !$OpenRealmStore}
+      {#if !realmState.expanded}
       <div class="mt-4 mb-4 w-full border-t border-t-selected"></div>
       <h1 class="text-2xl font-bold">Recently Uploaded<button class="text-base font-medium float-right p-1 bg-darkbg rounded-md hover:ring-3" onclick={() => {
-        $OpenRealmStore = true
+        realmState.expanded = true
       }}>Get More</button></h1>
           {#if !DBState.db.hideRealm}
             {#await getRisuHub({
@@ -32,9 +32,9 @@
               <div class="w-full flex gap-4 p-2 flex-wrap justify-center">
                   {#each charas as chara}
                       <RisuHubIcon onClick={() => {
-                        $OpenRealmStore = true
+                        realmState.expanded = true
                         if(DBState.db.realmDirectOpen){
-                            $RealmInitialOpenChar = chara
+                            realmState.autoOpenChar = chara
                         }
                       }} chara={chara} />
                   {/each}
@@ -89,7 +89,7 @@
 
       {:else}
         <div class="flex items-center mt-4">
-          <button class="mr-2 text-textcolor2 hover:text-green-500" onclick={() => ($OpenRealmStore = false)}>
+          <button class="mr-2 text-textcolor2 hover:text-green-500" onclick={() => (realmState.expanded = false)}>
             <ArrowLeft/>
           </button>
         </div>

--- a/src/lib/UI/Realm/RealmFrame.svelte
+++ b/src/lib/UI/Realm/RealmFrame.svelte
@@ -3,12 +3,12 @@
     import { shareRealmCardData } from "src/ts/realm";
     import { downloadPreset } from "src/ts/storage/preset-manager";
     import { DBState } from 'src/ts/stores.svelte';
-    import { selectedCharID, ShowRealmFrameStore } from "src/ts/stores.svelte";
+    import { selectedCharID, realmState } from "src/ts/stores.svelte";
     import { asBuffer, sleep } from "src/ts/util";
     import { onDestroy, onMount } from "svelte";
 
     const close =  () => {
-        $ShowRealmFrameStore = ''
+        realmState.uploadTarget = ''
     }
     let iframe: HTMLIFrameElement = $state(null)
     const tk = DBState.db?.account?.token;
@@ -28,7 +28,7 @@
         }
         if(e.data.type === 'success'){
             alertMd(`## Upload Success\n\nYour character has been uploaded to Realm successfully.\n\n${"```\nhttps://realm.risuai.net/character/" +  e.data.id + "\n```"}`)
-            if($ShowRealmFrameStore.startsWith('preset') || $ShowRealmFrameStore.startsWith('module')){
+            if(realmState.uploadTarget.startsWith('preset') || realmState.uploadTarget.startsWith('module')){
                 //TODO, add preset edit
             }
             else if(DBState.db.characters[$selectedCharID].type === 'character'){
@@ -58,8 +58,8 @@
             name: ArrayBuffer
         }
         
-        if($ShowRealmFrameStore.startsWith('preset')){
-            const predata = await downloadPreset(Number($ShowRealmFrameStore.split(':')[1]), 'return')
+        if(realmState.uploadTarget.startsWith('preset')){
+            const predata = await downloadPreset(Number(realmState.uploadTarget.split(':')[1]), 'return')
             const encodedPredata = predata.buf
             const encodedPredataName = new TextEncoder().encode(predata.data.name + '.risup')
             data = {
@@ -67,8 +67,8 @@
                 name: asBuffer(encodedPredataName.buffer)
             }
         }
-        else if($ShowRealmFrameStore.startsWith('module')){
-            const predata = DBState.db.modules[Number($ShowRealmFrameStore.split(':')[1])]
+        else if(realmState.uploadTarget.startsWith('module')){
+            const predata = DBState.db.modules[Number(realmState.uploadTarget.split(':')[1])]
             //@ts-expect-error adding type field for Realm export, not defined in module type
             predata.type = 'risuModule'
             const encodedPredata = new TextEncoder().encode(JSON.stringify(predata))
@@ -94,7 +94,7 @@
 
     const getUrl = () => {
         let url = tk ? `https://realm.risuai.net/upload?token=${tk}&token_id=${id}` : 'https://realm.risuai.net/upload'
-        if($ShowRealmFrameStore.startsWith('preset') || $ShowRealmFrameStore.startsWith('module')){
+        if(realmState.uploadTarget.startsWith('preset') || realmState.uploadTarget.startsWith('module')){
             //TODO, add preset edit
         }
         else if(DBState.db.characters[$selectedCharID].type === 'character' && DBState.db.characters[$selectedCharID].realmId){

--- a/src/lib/UI/Realm/RealmHubIcon.svelte
+++ b/src/lib/UI/Realm/RealmHubIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { BookIcon, ImageIcon, SmileIcon } from "@lucide/svelte";
     import { alertNormal } from "src/ts/alert";
-    import { hubURL, type hubType } from "src/ts/characterCards";
+    import { hubURL, type hubType } from "src/ts/characterCards.svelte";
     import { DBState } from "src/ts/stores.svelte";
     import { parseMultilangString } from "src/ts/util";
 

--- a/src/lib/UI/Realm/RealmMain.svelte
+++ b/src/lib/UI/Realm/RealmMain.svelte
@@ -4,7 +4,7 @@
     import { alertInput } from "src/ts/alert";
     import { language } from "src/lang";
     import RisuHubIcon from "./RealmHubIcon.svelte";
-    import { MobileGUI, realmState } from "src/ts/stores.svelte";
+    import { layoutState, realmState } from "src/ts/stores.svelte";
     import RealmPopUp from "./RealmPopUp.svelte";
 
     let openedData:null|hubType = $state(null)
@@ -73,7 +73,7 @@
         </button>
     </div>
 </div>
-{#if $MobileGUI}
+{#if layoutState.betaMobile.enabled}
 <div class="ml-4 flex items-start ">
     <div class="p-2 flex mb-3 overflow-x-auto rounded-lg border-darkborderc border gap-2">
         <button onclick={() => {

--- a/src/lib/UI/Realm/RealmMain.svelte
+++ b/src/lib/UI/Realm/RealmMain.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import { downloadRisuHub, getRisuHub, hubAdditionalHTML, type hubType } from "src/ts/characterCards";
+    import { downloadRisuHub, getRisuHub, hubAdditionalHTML, type hubType } from "src/ts/characterCards.svelte";
     import { ArrowLeft, ArrowRight, MenuIcon, SearchIcon, XIcon } from "@lucide/svelte";
     import { alertInput } from "src/ts/alert";
     import { language } from "src/lang";
     import RisuHubIcon from "./RealmHubIcon.svelte";
-    import { MobileGUI, RealmInitialOpenChar } from "src/ts/stores.svelte";
+    import { MobileGUI, realmState } from "src/ts/stores.svelte";
     import RealmPopUp from "./RealmPopUp.svelte";
 
     let openedData:null|hubType = $state(null)
@@ -42,9 +42,9 @@
 
 
     $effect(() => {
-        if($RealmInitialOpenChar){
-            openedData = $RealmInitialOpenChar
-            $RealmInitialOpenChar = null
+        if(realmState.autoOpenChar){
+            openedData = realmState.autoOpenChar
+            realmState.autoOpenChar = null
         }
     })
 </script>

--- a/src/lib/UI/Realm/RealmPopUp.svelte
+++ b/src/lib/UI/Realm/RealmPopUp.svelte
@@ -2,7 +2,7 @@
     import { BookIcon, FlagIcon, ImageIcon, PaperclipIcon, SmileIcon, TrashIcon } from "@lucide/svelte";
     import { language } from "src/lang";
     import { alertConfirm, alertInput, alertNormal } from "src/ts/alert";
-    import { hubURL, type hubType, downloadRisuHub, getRealmInfo } from "src/ts/characterCards";
+    import { hubURL, type hubType, downloadRisuHub, getRealmInfo } from "src/ts/characterCards.svelte";
     
     import { DBState } from 'src/ts/stores.svelte';
     import RealmLicense from "./RealmLicense.svelte";

--- a/src/lib/UI/Realm/RealmUpload.svelte
+++ b/src/lib/UI/Realm/RealmUpload.svelte
@@ -110,7 +110,7 @@
     import { XIcon } from "@lucide/svelte";
     import { language } from "src/lang";
     import { alertError } from "src/ts/alert";
-    import { shareRisuHub2 } from "src/ts/characterCards";
+    import { shareRisuHub2 } from "src/ts/characterCards.svelte";
     import type { character } from "src/ts/storage/types/character";
     import { DBState } from 'src/ts/stores.svelte';
     import TextInput from "../GUI/TextInput.svelte";

--- a/src/lib/VisualNovel/VisualNovelMain.svelte
+++ b/src/lib/VisualNovel/VisualNovelMain.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getCustomBackground } from "../../ts/characters";
+    import { getCustomBackground } from "../../ts/characters.svelte";
     
     import { DBState } from 'src/ts/stores.svelte';
     import BackgroundDom from "../ChatScreens/BackgroundDom.svelte";

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import "core-js/actual"
 import "./ts/storage/database.svelte"
 import {declareTest} from "./test/runTest"
 import App from "./App.svelte";
-import { loadData } from "./ts/bootstrap";
+import { loadData } from "./ts/bootstrap.svelte";
 import { initHotkey } from "./ts/hotkey.svelte";
 import { preLoadCheck } from "./preload";
 import { mount } from "svelte";

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import "./ts/storage/database.svelte"
 import {declareTest} from "./test/runTest"
 import App from "./App.svelte";
 import { loadData } from "./ts/bootstrap";
-import { initHotkey } from "./ts/hotkey";
+import { initHotkey } from "./ts/hotkey.svelte";
 import { preLoadCheck } from "./preload";
 import { mount } from "svelte";
 

--- a/src/ts/bootstrap.svelte.ts
+++ b/src/ts/bootstrap.svelte.ts
@@ -10,10 +10,9 @@ import {
 import { checkNullish, sleep, getBasename } from "./util"
 import { changeFullscreen, maximizeWindow } from "./gui/window"
 import { v4 as uuidv4 } from 'uuid';
-import { get } from "svelte/store";
 import { setDatabase, defaultSdDataFunc, getDatabase } from "./storage/database.svelte";
 import { checkRisuUpdate } from "./update";
-import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingStatusState } from "./stores.svelte";
+import { MobileGUI, botMakerMode, selectedCharID, appState, DBState, LoadingStatusState } from "./stores.svelte";
 import { loadPlugins } from "./plugins/plugins";
 import { alertError, alertMd, alertTOS, waitAlert } from "./alert";
 import { checkDriverInit } from "./drive/drive";
@@ -46,7 +45,7 @@ import { isTauri, isCapacitor, isInStandaloneMode } from "./platform";
  * Loads the application data.
  */
 export async function loadData() {
-    const loaded = get(loadedStore)
+    const loaded = appState.loaded
     if (!loaded) {
         try {
             if (isTauri) {
@@ -231,7 +230,7 @@ export async function loadData() {
                 initMobileGesture()
                 MobileGUI.set(true)
             }
-            loadedStore.set(true)
+            appState.loaded = true
             selectedCharID.set(-1)
             startObserveDom()
             assignIds()

--- a/src/ts/bootstrap.svelte.ts
+++ b/src/ts/bootstrap.svelte.ts
@@ -12,7 +12,7 @@ import { changeFullscreen, maximizeWindow } from "./gui/window"
 import { v4 as uuidv4 } from 'uuid';
 import { setDatabase, defaultSdDataFunc, getDatabase } from "./storage/database.svelte";
 import { checkRisuUpdate } from "./update";
-import { MobileGUI, botMakerMode, selectedCharID, appState, DBState, LoadingStatusState } from "./stores.svelte";
+import { layoutState, botMakerMode, selectedCharID, appState, DBState, LoadingStatusState } from "./stores.svelte";
 import { loadPlugins } from "./plugins/plugins";
 import { alertError, alertMd, alertTOS, waitAlert } from "./alert";
 import { checkDriverInit } from "./drive/drive";
@@ -228,7 +228,7 @@ export async function loadData() {
             }
             if ((db.betaMobileGUI && window.innerWidth <= 800) || import.meta.env.VITE_RISU_LITE === 'TRUE') {
                 initMobileGesture()
-                MobileGUI.set(true)
+                layoutState.betaMobile.enabled = true
             }
             appState.loaded = true
             selectedCharID.set(-1)

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -28,7 +28,7 @@ import { language } from "src/lang";
 import { startObserveDom } from "./observer.svelte";
 import { updateGuisize } from "./gui/guisize";
 import { updateLorebooks } from "./characters";
-import { initMobileGesture } from "./hotkey";
+import { initMobileGesture } from "./hotkey.svelte";
 import { moduleUpdate } from "./process/modules";
 import type { AccountStorage } from "./storage/accountStorage";
 import { makeColdData } from "./process/coldstorage.svelte";

--- a/src/ts/bootstrap.ts
+++ b/src/ts/bootstrap.ts
@@ -17,7 +17,7 @@ import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingS
 import { loadPlugins } from "./plugins/plugins";
 import { alertError, alertMd, alertTOS, waitAlert } from "./alert";
 import { checkDriverInit } from "./drive/drive";
-import { characterURLImport } from "./characterCards";
+import { characterURLImport } from "./characterCards.svelte";
 import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from "./storage/defaultPrompts";
 import { loadRisuAccountData } from "./drive/accounter";
 import { decodeRisuSave, encodeRisuSaveLegacy } from "./storage/risuSave";
@@ -27,7 +27,7 @@ import { autoServerBackup } from "./kei/backup";
 import { language } from "src/lang";
 import { startObserveDom } from "./observer.svelte";
 import { updateGuisize } from "./gui/guisize";
-import { updateLorebooks } from "./characters";
+import { updateLorebooks } from "./characters.svelte";
 import { initMobileGesture } from "./hotkey.svelte";
 import { moduleUpdate } from "./process/modules";
 import type { AccountStorage } from "./storage/accountStorage";

--- a/src/ts/characterCards.svelte.ts
+++ b/src/ts/characterCards.svelte.ts
@@ -11,10 +11,10 @@ import { type character } from './storage/types/character'
 import { checkNullish, decryptBuffer, isKnownUri, selectFileByDom, sleep } from "./util"
 import { language } from "src/lang"
 import { v4 as uuidv4, v4 } from 'uuid';
-import { characterFormatUpdate } from "./characters"
+import { characterFormatUpdate } from "./characters.svelte"
 import { AppendableBuffer, BlankWriter, checkCharOrder, downloadFile, forageStorage, loadAsset, LocalWriter, openURL, readImage, saveAsset, VirtualWriter } from "./globalApi.svelte"
 import { isTauri, isNodeServer, isCapacitor } from "src/ts/platform"
-import { SettingsMenuIndex, ShowRealmFrameStore, selectedCharID, settingsOpen } from "./stores.svelte"
+import { SettingsMenuIndex, realmState, selectedCharID, settingsOpen } from "./stores.svelte"
 import { checkImageType, convertImage, hasher } from "./parser.svelte"
 import { type CharacterCardV3, type LorebookEntry } from '@risuai/ccardlib'
 import { reencodeImage } from "./process/files/inlays"
@@ -723,7 +723,7 @@ export async function exportChar(charaID:number):Promise<string> {
         exportCharacterCard(char,'png', {spec: 'v2'})
     }
     else if(option.type === 'realm'){
-        ShowRealmFrameStore.set("character")
+        realmState.uploadTarget = "character"
     }
     else{
         return option.type

--- a/src/ts/characters.svelte.ts
+++ b/src/ts/characters.svelte.ts
@@ -8,7 +8,7 @@ import { language } from "../lang";
 import { checkNullish, selectMultipleFile, selectSingleFile } from "./util";
 import { getUserName } from "./persona";
 import { v4 as uuidv4, v4 } from 'uuid';
-import { MobileGUIStack, realmState, selectedCharID } from "./stores.svelte";
+import { layoutState, realmState, selectedCharID } from "./stores.svelte";
 import { AppendableBuffer, changeChatTo, checkCharOrder, downloadFile, getFileSrc, requiresFullEncoderReload } from "./globalApi.svelte";
 import { updateInlayScreen } from "./process/inlayScreen";
 import { checkImageType, parseMarkdownSafe } from "./parser.svelte";
@@ -858,13 +858,13 @@ export async function removeChar(index:number,name:string, type:'normal'|'perman
 export async function addCharacter(arg:{
     reseter?:()=>any,
 } = {}){
-    MobileGUIStack.set(100)
+    layoutState.betaMobile.stack = 100
     const reseter = arg.reseter ?? (() => {})
     const r = await alertAddCharacter()
     if(r === 'importFromRealm'){
         selectedCharID.set(-1)
         realmState.expanded = true
-        MobileGUIStack.set(0)
+        layoutState.betaMobile.stack = 0
         return
     }
     reseter();
@@ -879,14 +879,14 @@ export async function addCharacter(arg:{
             await importCharacter()
             break
         default:
-            MobileGUIStack.set(1)
+            layoutState.betaMobile.stack = 1
             return
     }
     const db = getDatabase()
     if(db.characters[db.characters.length-1]){
         changeChar(db.characters.length-1)
     }
-    MobileGUIStack.set(1)
+    layoutState.betaMobile.stack = 1
 }
 
 export function changeChar(index: number, arg:{

--- a/src/ts/characters.svelte.ts
+++ b/src/ts/characters.svelte.ts
@@ -8,13 +8,13 @@ import { language } from "../lang";
 import { checkNullish, selectMultipleFile, selectSingleFile } from "./util";
 import { getUserName } from "./persona";
 import { v4 as uuidv4, v4 } from 'uuid';
-import { MobileGUIStack, OpenRealmStore, selectedCharID } from "./stores.svelte";
+import { MobileGUIStack, realmState, selectedCharID } from "./stores.svelte";
 import { AppendableBuffer, changeChatTo, checkCharOrder, downloadFile, getFileSrc, requiresFullEncoderReload } from "./globalApi.svelte";
 import { updateInlayScreen } from "./process/inlayScreen";
 import { checkImageType, parseMarkdownSafe } from "./parser.svelte";
 import { translateHTML } from "./translator/translator";
 import { doingChat } from "./process/index.svelte";
-import { importCharacter } from "./characterCards";
+import { importCharacter } from "./characterCards.svelte";
 import { PngChunk } from "./pngChunk";
 import type { Database } from "./storage/types";
 
@@ -863,7 +863,7 @@ export async function addCharacter(arg:{
     const r = await alertAddCharacter()
     if(r === 'importFromRealm'){
         selectedCharID.set(-1)
-        OpenRealmStore.set(true)
+        realmState.expanded = true
         MobileGUIStack.set(0)
         return
     }

--- a/src/ts/creation/creator.ts
+++ b/src/ts/creation/creator.ts
@@ -5,7 +5,7 @@ import { checkCharOrder, saveAsset } from "../globalApi.svelte";
 import { globalFetch } from "../fetch";
 import { isTauri, isNodeServer, isCapacitor } from "src/ts/platform"
 import { tokenize } from "../tokenizer";
-import { createBlankChar } from "../characters";
+import { createBlankChar } from "../characters.svelte";
 import { getDatabase, setDatabase } from "../storage/database.svelte";
 import { type character } from '../storage/types/character';
 import { sleep } from "../util";

--- a/src/ts/drive/accounter.ts
+++ b/src/ts/drive/accounter.ts
@@ -1,4 +1,4 @@
-import { hubURL } from "../characterCards"
+import { hubURL } from "../characterCards.svelte"
 import { getDatabase, setDatabase } from "../storage/database.svelte"
 import { alertConfirm, alertError, alertMd, alertNormal, alertSelect, alertWait } from "../alert"
 import { AppendableBuffer } from "../globalApi.svelte"

--- a/src/ts/drive/backuplocal.ts
+++ b/src/ts/drive/backuplocal.ts
@@ -6,7 +6,7 @@ import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
 import { getDatabase, setDatabaseLite } from "../storage/database.svelte";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { sleep } from "../util";
-import { hubURL } from "../characterCards";
+import { hubURL } from "../characterCards.svelte";
 
 export async function SaveLocalBackup(){
     alertWait("Saving local backup...")

--- a/src/ts/drive/drive.ts
+++ b/src/ts/drive/drive.ts
@@ -7,7 +7,7 @@ import { BaseDirectory, exists, readFile, readDir, writeFile } from "@tauri-apps
 import { language } from "../../lang";
 import { relaunch } from '@tauri-apps/plugin-process';
 import { sleep, getBasename } from "../util";
-import { hubURL } from "../characterCards";
+import { hubURL } from "../characterCards.svelte";
 import { decodeRisuSave, encodeRisuSaveLegacy } from "../storage/risuSave";
 
 export async function checkDriver(type:'save'|'load'|'loadtauri'|'savetauri'|'reftoken'){

--- a/src/ts/fetch.ts
+++ b/src/ts/fetch.ts
@@ -1,7 +1,7 @@
 import { fetch as TauriHTTPFetch } from "@tauri-apps/plugin-http";
 import { AppendableBuffer } from "./globalApi.svelte";
 import { CapacitorHttp, registerPlugin } from "@capacitor/core";
-import { hubURL } from "./characterCards";
+import { hubURL } from "./characterCards.svelte";
 import { isTauri, isNodeServer, isCapacitor } from "./platform";
 import { DBState } from "./stores.svelte";
 import { listen } from '@tauri-apps/api/event'

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -16,7 +16,7 @@ import { selectedCharID, DBState, selIdState, ReloadGUIPointer } from "./stores.
 import { alertConfirm, alertNormal, alertNormalWait, alertSelect } from "./alert";
 import { syncDrive } from "./drive/drive";
 import { hasher } from "./parser.svelte";
-import { hubURL } from "./characterCards";
+import { hubURL } from "./characterCards.svelte";
 import { decodeRisuSave, RisuSaveEncoder, type toSaveType } from "./storage/risuSave";
 import { AutoStorage } from "./storage/autoStorage";
 import { saveDbKei } from "./kei/backup";

--- a/src/ts/hotkey.svelte.ts
+++ b/src/ts/hotkey.svelte.ts
@@ -2,7 +2,7 @@ import { get } from "svelte/store"
 import { alertMd, alertSelect, alertToast, alertWait, doingAlert, alertRequestLogs } from "./alert"
 import { getDatabase  } from "./storage/database.svelte"
 import { changeToPreset as changeToPreset2 } from './storage/preset-manager'
-import { alertStore, MobileGUIStack, MobileSideBar, modalState, realmState, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
+import { alertStore, layoutState, modalState, realmState, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
 import { language } from "src/lang"
 import { updateTextThemeAndCSS } from "./gui/colorscheme"
 import { defaultHotkeys } from "./defaulthotkeys"
@@ -355,25 +355,25 @@ export function initMobileGesture(){
 
             if(moveX > 50 && Math.abs(moveY) < Math.abs(moveX)){
                 if(get(selectedCharID) === -1){
-                    if(get(MobileGUIStack) > 0){
-                        MobileGUIStack.update(v => v - 1)
+                    if(layoutState.betaMobile.stack > 0){
+                        layoutState.betaMobile.stack -= 1
                     }
                 }
                 else{
-                    if(get(MobileSideBar) > 0){
-                        MobileSideBar.update(v => v - 1)
+                    if(layoutState.betaMobile.sideBar > 0){
+                        layoutState.betaMobile.sideBar -= 1
                     }
                 }
             }
             else if(moveX < -50 && Math.abs(moveY) < Math.abs(moveX)){
                 if(get(selectedCharID) === -1){
-                    if(get(MobileGUIStack) < 2){
-                        MobileGUIStack.update(v => v + 1)
+                    if(layoutState.betaMobile.stack < 2){
+                        layoutState.betaMobile.stack += 1;
                     }
                 }
                 else{
-                    if(get(MobileSideBar) < 3){
-                        MobileSideBar.update(v => v + 1)
+                    if(layoutState.betaMobile.sideBar < 3){
+                        layoutState.betaMobile.sideBar += 1
                     }
                 }
             }

--- a/src/ts/hotkey.svelte.ts
+++ b/src/ts/hotkey.svelte.ts
@@ -2,7 +2,7 @@ import { get } from "svelte/store"
 import { alertMd, alertSelect, alertToast, alertWait, doingAlert, alertRequestLogs } from "./alert"
 import { getDatabase  } from "./storage/database.svelte"
 import { changeToPreset as changeToPreset2 } from './storage/preset-manager'
-import { alertStore, MobileGUIStack, MobileSideBar, openPersonaList, openPresetList, OpenRealmStore, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
+import { alertStore, MobileGUIStack, MobileSideBar, modalState, OpenRealmStore, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
 import { language } from "src/lang"
 import { updateTextThemeAndCSS } from "./gui/colorscheme"
 import { defaultHotkeys } from "./defaulthotkeys"
@@ -103,11 +103,11 @@ export function initHotkey(){
                     break
                 }
                 case 'presets':{
-                    openPresetList.set(!get(openPresetList))
+                    modalState.preset = !modalState.preset
                     break
                 }
                 case 'persona':{
-                    openPersonaList.set(!get(openPersonaList))
+                    modalState.persona = !modalState.persona
                     break
                 }
                 case 'toggleCSS':{
@@ -307,10 +307,10 @@ async function quickMenu(){
     ])
     const sel = parseInt(selStr)
     if(sel === 0){
-        openPresetList.set(!get(openPresetList))
+        modalState.preset = !modalState.preset
     }
     if(sel === 1){
-        openPersonaList.set(!get(openPersonaList))
+        modalState.persona = !modalState.persona
     }
 }
 

--- a/src/ts/hotkey.svelte.ts
+++ b/src/ts/hotkey.svelte.ts
@@ -2,7 +2,7 @@ import { get } from "svelte/store"
 import { alertMd, alertSelect, alertToast, alertWait, doingAlert, alertRequestLogs } from "./alert"
 import { getDatabase  } from "./storage/database.svelte"
 import { changeToPreset as changeToPreset2 } from './storage/preset-manager'
-import { alertStore, MobileGUIStack, MobileSideBar, modalState, OpenRealmStore, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
+import { alertStore, MobileGUIStack, MobileSideBar, modalState, realmState, PlaygroundStore, QuickSettings, SafeModeStore, selectedCharID, settingsOpen } from "./stores.svelte"
 import { language } from "src/lang"
 import { updateTextThemeAndCSS } from "./gui/colorscheme"
 import { defaultHotkeys } from "./defaulthotkeys"
@@ -128,7 +128,7 @@ export function initHotkey(){
                     }
                     selectedCharID.set(sorted[currentIndex - 1].i)
                     PlaygroundStore.set(0)
-                    OpenRealmStore.set(false)
+                    realmState.expanded = false
                     break
                 }
                 case 'nextChar':{
@@ -144,7 +144,7 @@ export function initHotkey(){
                     }
                     selectedCharID.set(sorted[currentIndex + 1].i)
                     PlaygroundStore.set(0)
-                    OpenRealmStore.set(false)
+                    realmState.expanded = false
                     break
                 }
                 case 'quickMenu':{

--- a/src/ts/kei/kei.ts
+++ b/src/ts/kei/kei.ts
@@ -1,4 +1,4 @@
-import { hubURL } from "../characterCards";
+import { hubURL } from "../characterCards.svelte";
 import { getDatabase } from "../storage/database.svelte";
 
 export function keiServerURL(){

--- a/src/ts/parser.svelte.ts
+++ b/src/ts/parser.svelte.ts
@@ -15,7 +15,7 @@ import css, { type CssAtRuleAST } from '@adobe/css-tools'
 import { selectedCharID } from './stores.svelte';
 import { calcString } from './process/infunctions';
 import { parseKeyValue, pickHashRand, replaceAsync} from './util';
-import { findCharacterbyId } from "./characters";
+import { findCharacterbyId } from "./characters.svelte";
 import { getPersonaPrompt } from "./persona";
 import { getUserIcon } from "./persona";
 import { getUserName } from "./persona";

--- a/src/ts/process/group.ts
+++ b/src/ts/process/group.ts
@@ -1,5 +1,5 @@
 import { shuffle } from "lodash";
-import { findCharacterbyId } from "../characters";
+import { findCharacterbyId } from "../characters.svelte";
 import { alertConfirm, alertError, alertSelectChar } from "../alert";
 import { language } from "src/lang";
 import { get } from "svelte/store";

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -36,7 +36,7 @@ import { hypaMemoryV2 } from "./memory/hypav2";
 import { runLuaEditTrigger } from "./scriptings";
 import { parseChatML } from "../parser.svelte";
 import { getModelInfo, LLMFlags } from "../model/modellist";
-import { hypaMemoryV3 } from "./memory/hypav3";
+import { hypaMemoryV3 } from "./memory/hypav3.svelte";
 import { getModuleAssets, getModuleToggles } from "./modules";
 import { readImage } from "../globalApi.svelte";
 import { type OpenAIChat, type MultiModal } from "./types";

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -11,7 +11,7 @@ import { alertError, alertToast } from "../alert";
 import { loadLoreBookV3Prompt } from "./lorebook.svelte";
 import { isLastCharPunctuation, trimUntilPunctuation, parseToggleSyntax } from "../util";
 import { getAuthorNoteDefaultText } from "./prompt";
-import { findCharacterbyId } from "../characters";
+import { findCharacterbyId } from "../characters.svelte";
 import { getPersonaPrompt } from "../persona";
 import { getUserName } from "../persona";
 import { requestChatData } from "./request/request";

--- a/src/ts/process/lorebook.svelte.ts
+++ b/src/ts/process/lorebook.svelte.ts
@@ -5,7 +5,7 @@ import { type loreBook } from '../storage/types/character';
 import { DBState } from '../stores.svelte';
 import { tokenize } from "../tokenizer";
 import { pickHashRand, selectSingleFile } from "../util";
-import { findCharacterbyId } from "../characters";
+import { findCharacterbyId } from "../characters.svelte";
 import { alertError, alertNormal } from "../alert";
 import { language } from "../../lang";
 import { downloadFile } from "../globalApi.svelte";

--- a/src/ts/process/memory/hypav3.svelte.ts
+++ b/src/ts/process/memory/hypav3.svelte.ts
@@ -16,7 +16,7 @@ import { type OpenAIChat } from "../types";
 import { requestChatData } from "../request/request";
 import { chatCompletion, unloadEngine } from "../webllm";
 import { parseChatML } from "src/ts/parser.svelte";
-import { hypaV3ProgressStore } from "src/ts/stores.svelte";
+import { hypaV3State } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
 import { type HypaV3Preset, type HypaV3Settings, createHypaV3Preset } from "./hypav3Preset";
 
@@ -354,12 +354,12 @@ async function hypaMemoryV3MainExp(
     });
 
     rateLimiter.taskQueueChangeCallback = (queuedCount) => {
-      hypaV3ProgressStore.set({
+      hypaV3State.progress = {
         open: true,
         miniMsg: `${rateLimiter.queuedTaskCount}`,
         msg: `${logPrefix} Summarizing...`,
         subMsg: `${rateLimiter.queuedTaskCount} queued`,
-      });
+      }
     };
 
     const summarizationTasks = toSummarizeArray.map(
@@ -385,12 +385,12 @@ async function hypaMemoryV3MainExp(
     );
     // End of performance measurement: summarize
 
-    hypaV3ProgressStore.set({
+    hypaV3State.progress = {
       open: false,
       miniMsg: "",
       msg: "",
       subMsg: "",
-    });
+    }
 
     // Note:
     // We can't save some successful summaries to the DB temporarily
@@ -597,12 +597,12 @@ async function hypaMemoryV3MainExp(
     });
 
     processor.progressCallback = (queuedCount) => {
-      hypaV3ProgressStore.set({
+      hypaV3State.progress = {
         open: true,
         miniMsg: `${queuedCount}`,
         msg: `${logPrefix} Similarity searching...`,
         subMsg: `${queuedCount} queued`,
-      });
+      }
     };
 
     try {
@@ -628,12 +628,12 @@ async function hypaMemoryV3MainExp(
         memory: toSerializableHypaV3Data(data),
       };
     } finally {
-      hypaV3ProgressStore.set({
+      hypaV3State.progress = {
         open: false,
         miniMsg: "",
         msg: "",
         subMsg: "",
-      });
+      }
     }
 
     const recentChats = chats
@@ -744,12 +744,12 @@ async function hypaMemoryV3MainExp(
           memory: toSerializableHypaV3Data(data),
         };
       } finally {
-        hypaV3ProgressStore.set({
+        hypaV3State.progress = {
           open: false,
           miniMsg: "",
           msg: "",
           subMsg: "",
-        });
+        }
       }
     }
 

--- a/src/ts/process/memory/hypav3.ts
+++ b/src/ts/process/memory/hypav3.ts
@@ -18,33 +18,10 @@ import { chatCompletion, unloadEngine } from "../webllm";
 import { parseChatML } from "src/ts/parser.svelte";
 import { hypaV3ProgressStore } from "src/ts/stores.svelte";
 import { type ChatTokenizer } from "src/ts/tokenizer";
+import { type HypaV3Preset, type HypaV3Settings, createHypaV3Preset } from "./hypav3Preset";
 
-export interface HypaV3Preset {
-  name: string;
-  settings: HypaV3Settings;
-}
-
-export interface HypaV3Settings {
-  summarizationModel: string;
-  summarizationPrompt: string;
-  reSummarizationPrompt: string;
-  memoryTokensRatio: number;
-  extraSummarizationRatio: number;
-  maxChatsPerSummary: number;
-  recentMemoryRatio: number;
-  similarMemoryRatio: number;
-  enableSimilarityCorrection: boolean;
-  preserveOrphanedMemory: boolean;
-  processRegexScript: boolean;
-  doNotSummarizeUserMessage: boolean;
-  // Experimental
-  useExperimentalImpl: boolean;
-  summarizationRequestsPerMinute: number;
-  summarizationMaxConcurrent: number;
-  embeddingRequestsPerMinute: number;
-  embeddingMaxConcurrent: number;
-  alwaysToggleOn: boolean;
-}
+// Re-export for backward compatibility
+export { type HypaV3Preset, type HypaV3Settings, createHypaV3Preset };
 
 interface HypaV3Data {
   summaries: Summary[];
@@ -1332,6 +1309,58 @@ async function hypaMemoryV3Main(
       );
     });
 
+    interface SummaryChunkVector {
+      chunk: SummaryChunk;
+      vector: memoryVector;
+    }
+
+    class HypaProcesserEx extends HypaProcesser {
+      // Maintain references to SummaryChunks and their associated memoryVectors
+      summaryChunkVectors: SummaryChunkVector[] = [];
+
+      async addSummaryChunks(chunks: SummaryChunk[]): Promise<void> {
+        // Maintain the superclass's caching structure by adding texts
+        const texts = chunks.map((chunk) => chunk.text);
+
+        await this.addText(texts);
+
+        // Create new SummaryChunkVectors
+        const newSummaryChunkVectors: SummaryChunkVector[] = [];
+
+        for (const chunk of chunks) {
+          const vector = this.vectors.find((v) => v.content === chunk.text);
+
+          if (!vector) {
+            throw new Error(
+              `Failed to create vector for summary chunk:\n${chunk.text}`
+            );
+          }
+
+          newSummaryChunkVectors.push({
+            chunk,
+            vector,
+          });
+        }
+
+        // Append new SummaryChunkVectors to the existing collection
+        this.summaryChunkVectors.push(...newSummaryChunkVectors);
+      }
+
+      async similaritySearchScoredEx(
+        query: string
+      ): Promise<[SummaryChunk, number][]> {
+        const queryVector = (await this.getEmbeds(query))[0];
+
+        return this.summaryChunkVectors
+          .map((scv) => ({
+            chunk: scv.chunk,
+            similarity: similarity(queryVector, scv.vector.embedding),
+          }))
+          .sort((a, b) => b.similarity - a.similarity)
+          .map((result) => [result.chunk, result.similarity]);
+      }
+    }
+
     // Initialize embedding processor
     const processor = new HypaProcesserEx(db.hypaModel);
     processor.oaikey = db.supaMemoryKey;
@@ -1751,50 +1780,6 @@ export function getCurrentHypaV3Preset(): HypaV3Preset {
   return preset;
 }
 
-export function createHypaV3Preset(
-  name = "New Preset",
-  existingSettings = {}
-): HypaV3Preset {
-  const settings: HypaV3Settings = {
-    summarizationModel: "subModel",
-    summarizationPrompt: "",
-    reSummarizationPrompt: "",
-    memoryTokensRatio: 0.2,
-    extraSummarizationRatio: 0,
-    maxChatsPerSummary: 6,
-    recentMemoryRatio: 0.4,
-    similarMemoryRatio: 0.4,
-    enableSimilarityCorrection: false,
-    preserveOrphanedMemory: false,
-    processRegexScript: false,
-    doNotSummarizeUserMessage: false,
-    // Experimental
-    useExperimentalImpl: false,
-    summarizationRequestsPerMinute: 20,
-    summarizationMaxConcurrent: 1,
-    embeddingRequestsPerMinute: 100,
-    embeddingMaxConcurrent: 1,
-    alwaysToggleOn: false,
-  };
-
-  if (
-    existingSettings &&
-    typeof existingSettings === "object" &&
-    !Array.isArray(existingSettings)
-  ) {
-    for (const [key, value] of Object.entries(existingSettings)) {
-      if (key in settings && typeof value === typeof settings[key]) {
-        settings[key] = value;
-      }
-    }
-  }
-
-  return {
-    name,
-    settings,
-  };
-}
-
 function simpleCC<T>(
   scoredLists: [T, number][][],
   weightFunc?: (listIndex: number, totalLists: number) => number
@@ -1879,56 +1864,4 @@ function normalizeScores<T>(scoredList: [T, number][]): [T, number][] {
     const normalizedScore = (score - minScore) / (maxScore - minScore);
     return [item, normalizedScore];
   });
-}
-
-interface SummaryChunkVector {
-  chunk: SummaryChunk;
-  vector: memoryVector;
-}
-
-class HypaProcesserEx extends HypaProcesser {
-  // Maintain references to SummaryChunks and their associated memoryVectors
-  summaryChunkVectors: SummaryChunkVector[] = [];
-
-  async addSummaryChunks(chunks: SummaryChunk[]): Promise<void> {
-    // Maintain the superclass's caching structure by adding texts
-    const texts = chunks.map((chunk) => chunk.text);
-
-    await this.addText(texts);
-
-    // Create new SummaryChunkVectors
-    const newSummaryChunkVectors: SummaryChunkVector[] = [];
-
-    for (const chunk of chunks) {
-      const vector = this.vectors.find((v) => v.content === chunk.text);
-
-      if (!vector) {
-        throw new Error(
-          `Failed to create vector for summary chunk:\n${chunk.text}`
-        );
-      }
-
-      newSummaryChunkVectors.push({
-        chunk,
-        vector,
-      });
-    }
-
-    // Append new SummaryChunkVectors to the existing collection
-    this.summaryChunkVectors.push(...newSummaryChunkVectors);
-  }
-
-  async similaritySearchScoredEx(
-    query: string
-  ): Promise<[SummaryChunk, number][]> {
-    const queryVector = (await this.getEmbeds(query))[0];
-
-    return this.summaryChunkVectors
-      .map((scv) => ({
-        chunk: scv.chunk,
-        similarity: similarity(queryVector, scv.vector.embedding),
-      }))
-      .sort((a, b) => b.similarity - a.similarity)
-      .map((result) => [result.chunk, result.similarity]);
-  }
 }

--- a/src/ts/process/memory/hypav3Preset.ts
+++ b/src/ts/process/memory/hypav3Preset.ts
@@ -1,0 +1,70 @@
+export interface HypaV3Preset {
+  name: string;
+  settings: HypaV3Settings;
+}
+
+export interface HypaV3Settings {
+  summarizationModel: string;
+  summarizationPrompt: string;
+  reSummarizationPrompt: string;
+  memoryTokensRatio: number;
+  extraSummarizationRatio: number;
+  maxChatsPerSummary: number;
+  recentMemoryRatio: number;
+  similarMemoryRatio: number;
+  enableSimilarityCorrection: boolean;
+  preserveOrphanedMemory: boolean;
+  processRegexScript: boolean;
+  doNotSummarizeUserMessage: boolean;
+  // Experimental
+  useExperimentalImpl: boolean;
+  summarizationRequestsPerMinute: number;
+  summarizationMaxConcurrent: number;
+  embeddingRequestsPerMinute: number;
+  embeddingMaxConcurrent: number;
+  alwaysToggleOn: boolean;
+}
+
+export function createHypaV3Preset(
+  name = "New Preset",
+  existingSettings = {}
+): HypaV3Preset {
+  const settings: HypaV3Settings = {
+    summarizationModel: "subModel",
+    summarizationPrompt: "",
+    reSummarizationPrompt: "",
+    memoryTokensRatio: 0.2,
+    extraSummarizationRatio: 0,
+    maxChatsPerSummary: 6,
+    recentMemoryRatio: 0.4,
+    similarMemoryRatio: 0.4,
+    enableSimilarityCorrection: false,
+    preserveOrphanedMemory: false,
+    processRegexScript: false,
+    doNotSummarizeUserMessage: false,
+    // Experimental
+    useExperimentalImpl: false,
+    summarizationRequestsPerMinute: 20,
+    summarizationMaxConcurrent: 1,
+    embeddingRequestsPerMinute: 100,
+    embeddingMaxConcurrent: 1,
+    alwaysToggleOn: false,
+  };
+
+  if (
+    existingSettings &&
+    typeof existingSettings === "object" &&
+    !Array.isArray(existingSettings)
+  ) {
+    for (const [key, value] of Object.entries(existingSettings)) {
+      if (key in settings && typeof value === typeof settings[key]) {
+        settings[key] = value;
+      }
+    }
+  }
+
+  return {
+    name,
+    settings,
+  };
+}

--- a/src/ts/process/processzip.ts
+++ b/src/ts/process/processzip.ts
@@ -3,7 +3,7 @@ import * as fflate from "fflate";
 import { asBuffer, sleep } from "../util";
 import { alertStore } from "../alert";
 import { hasher } from "../parser.svelte";
-import { hubURL } from "../characterCards";
+import { hubURL } from "../characterCards.svelte";
 
 export async function processZip(dataArray: Uint8Array): Promise<string> {
     const jszip = await import("jszip");

--- a/src/ts/realm.ts
+++ b/src/ts/realm.ts
@@ -1,4 +1,4 @@
-import { exportCharacterCard } from "./characterCards";
+import { exportCharacterCard } from "./characterCards.svelte";
 import { VirtualWriter } from "./globalApi.svelte";
 import { getCurrentCharacter, getDatabase } from "./storage/database.svelte";
 import { type character } from './storage/types/character';

--- a/src/ts/sionyw.ts
+++ b/src/ts/sionyw.ts
@@ -1,4 +1,4 @@
-import { hubURL } from "./characterCards";
+import { hubURL } from "./characterCards.svelte";
 import { fetchNative } from "./fetch";
 import { DBState } from "./stores.svelte";
 import { readFile, BaseDirectory, writeFile } from "@tauri-apps/plugin-fs";

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -4,7 +4,7 @@ import { saveAsset as saveImageGlobal } from '../globalApi.svelte';
 import { defaultAutoSuggestPrompt, defaultJailbreak, defaultMainPrompt } from './defaultPrompts';
 import { prebuiltNAIpresets } from '../process/templates/templates';
 import { defaultColorScheme } from '../gui/colorscheme';
-import { createHypaV3Preset } from '../process/memory/hypav3'
+import { createHypaV3Preset } from '../process/memory/hypav3Preset'
 import { isTauri, isNodeServer } from "src/ts/platform"
 import { DBState, selectedCharID } from '../stores.svelte';
 import { LLMFormat } from '../model/modellist';

--- a/src/ts/storage/types/chat.ts
+++ b/src/ts/storage/types/chat.ts
@@ -1,5 +1,5 @@
 import type { SerializableHypaV2Data } from 'src/ts/process/memory/hypav2';
-import type { SerializableHypaV3Data } from 'src/ts/process/memory/hypav3';
+import type { SerializableHypaV3Data } from 'src/ts/process/memory/hypav3.svelte';
 import type { loreBook } from './character';
 import type { OpenAIChat } from 'src/ts/process/index.svelte';
 

--- a/src/ts/storage/types/database.ts
+++ b/src/ts/storage/types/database.ts
@@ -4,7 +4,7 @@ import type { OobaChatCompletionRequestParams } from 'src/ts/model/ooba';
 import type { LLMFormat, LLMFlags, LLMTokenizer } from 'src/ts/model/types';
 import type { RisuPlugin } from 'src/ts/plugins/plugins';
 import type { HypaModel } from 'src/ts/process/memory/hypamemory';
-import type { HypaV3Settings, HypaV3Preset } from 'src/ts/process/memory/hypav3';
+import type { HypaV3Settings, HypaV3Preset } from 'src/ts/process/memory/hypav3.svelte';
 import type { NAISettings } from 'src/ts/process/models/nai';
 import type { RisuModule } from 'src/ts/process/modules';
 import type { PromptItem, PromptSettings } from 'src/ts/process/prompt';

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -25,8 +25,12 @@ export const SizeStore = writable({
 const t = 'https://raw.githubusercontent.com/ProjectAliceDev/ProjectAliceDev.github.io/master/'
 export const loadedStore = writable(false)
 export const DynamicGUI = writable(false)
-export const sideBarClosing = writable(false)
-export const sideBarStore = writable(window.innerWidth > 1024)
+
+export const sideBarState = $state({
+    open: window.innerWidth > 1024,
+    closing: false
+})
+
 export const selectedCharID = writable(-1)
 export const CurrentTriggerIdStore = writable<string | null>(null)
 export const CharEmotion = writable({} as {[key:string]: [string, string, number][]})

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -66,13 +66,17 @@ export const alertStore = writable({
     type: 'none',
     msg: 'n',
 } as alertData)
-export const hypaV3ModalOpen = writable(false)
-export const hypaV3ProgressStore = writable({
+
+export const hypaV3State = $state({
     open: false,
-    miniMsg: '',
-    msg: '',
-    subMsg: '',
+    progress: {
+        open: false,
+        miniMsg: '',
+        msg: '',
+        subMsg: '',
+    }
 })
+
 export const selIdState = $state({
     selId: -1
 })

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -19,6 +19,12 @@ export const layoutState = $state({
     width: 0,
     height: 0,
     compactMode: false,
+    ShowVN: false,
+    betaMobile: {
+        enabled: false,
+        stack: 0,
+        sideBar: 0,
+    },
 })
 
 export const appState = $state({
@@ -43,10 +49,7 @@ export const ViewBoxsize = writable({ width: 12 * 16, height: 12 * 16 }); // Def
 export const settingsOpen = writable(false)
 export const botMakerMode = writable(false)
 export const moduleBackgroundEmbedding = writable('')
-export const MobileGUI = writable(false)
-export const MobileGUIStack = writable(0)
-export const MobileSideBar = writable(0)
-export const ShowVN = writable(false)
+
 export const SettingsMenuIndex = writable(-1)
 export const ReloadGUIPointer = writable(0)
 export const ReloadChatPointer = writable({} as Record<number, number>)
@@ -62,7 +65,6 @@ export const PlaygroundStore = writable(0)
 export const HideIconStore = writable(false)
 export const CustomCSSStore = writable('')
 export const SafeModeStore = writable(false)
-export const MobileSearch = writable('')
 export const CharConfigSubMenu = writable(0)
 export const CustomGUISettingMenuStore = writable(false)
 export const alertStore = writable({

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -21,8 +21,10 @@ export const SizeState = $state({
     h: 0
 })
 
-const t = 'https://raw.githubusercontent.com/ProjectAliceDev/ProjectAliceDev.github.io/master/'
-export const loadedStore = writable(false)
+export const appState = $state({
+    loaded: false
+})
+
 export const DynamicGUI = writable(false)
 
 export const sideBarState = $state({

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -6,7 +6,7 @@ import type { simpleCharacterArgument } from "./parser.svelte";
 import type { alertData } from "./alert";
 import { moduleUpdate } from "./process/modules";
 import { resetScriptCache } from "./process/scripts";
-import type { hubType } from "./characterCards";
+import type { hubType } from "./characterCards.svelte";
 import type { PluginSafetyErrors } from "./plugins/pluginSafety";
 
 function updateSize(){
@@ -51,9 +51,13 @@ export const SettingsMenuIndex = writable(-1)
 export const ReloadGUIPointer = writable(0)
 export const ReloadChatPointer = writable({} as Record<number, number>)
 export const ScrollToMessageStore = $state({ value: -1 })
-export const OpenRealmStore = writable(false)
-export const RealmInitialOpenChar = writable<null | hubType>(null)
-export const ShowRealmFrameStore = writable('')
+
+export const realmState = $state({
+    expanded: false, 
+    autoOpenChar: null as  hubType | null,
+    uploadTarget: ''
+})
+
 export const PlaygroundStore = writable(0)
 export const HideIconStore = writable(false)
 export const CustomCSSStore = writable('')

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -10,14 +10,13 @@ import type { hubType } from "./characterCards";
 import type { PluginSafetyErrors } from "./plugins/pluginSafety";
 
 function updateSize(){
-    SizeStore.set({
-        w: window.innerWidth,
-        h: window.innerHeight
-    })
+    SizeState.w = window.innerWidth
+    SizeState.h = window.innerHeight
+
     DynamicGUI.set(window.innerWidth <= 1024)
 }
 
-export const SizeStore = writable({
+export const SizeState = $state({
     w: 0,
     h: 0
 })

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -10,22 +10,20 @@ import type { hubType } from "./characterCards.svelte";
 import type { PluginSafetyErrors } from "./plugins/pluginSafety";
 
 function updateSize(){
-    SizeState.w = window.innerWidth
-    SizeState.h = window.innerHeight
-
-    DynamicGUI.set(window.innerWidth <= 1024)
+    layoutState.width = window.innerWidth
+    layoutState.height = window.innerHeight
+    layoutState.compactMode = window.innerWidth <= 1024
 }
 
-export const SizeState = $state({
-    w: 0,
-    h: 0
+export const layoutState = $state({
+    width: 0,
+    height: 0,
+    compactMode: false,
 })
 
 export const appState = $state({
-    loaded: false
+    loaded: false,
 })
-
-export const DynamicGUI = writable(false)
 
 export const sideBarState = $state({
     open: window.innerWidth > 1024,

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -31,6 +31,12 @@ export const sideBarState = $state({
     closing: false
 })
 
+export const modalState = $state({
+    preset: false,
+    persona: false,
+    bookmark: false
+})
+
 export const selectedCharID = writable(-1)
 export const CurrentTriggerIdStore = writable<string | null>(null)
 export const CharEmotion = writable({} as {[key:string]: [string, string, number][]})
@@ -38,9 +44,6 @@ export const ViewBoxsize = writable({ width: 12 * 16, height: 12 * 16 }); // Def
 export const settingsOpen = writable(false)
 export const botMakerMode = writable(false)
 export const moduleBackgroundEmbedding = writable('')
-export const openPresetList = writable(false)
-export const openPersonaList = writable(false)
-export const bookmarkListOpen = writable(false)
 export const MobileGUI = writable(false)
 export const MobileGUIStack = writable(0)
 export const MobileSideBar = writable(0)

--- a/src/ts/stores.svelte.ts
+++ b/src/ts/stores.svelte.ts
@@ -157,6 +157,7 @@ openId: 0,
 })
 
 //Set might be more ideal, however since Svelte doesn't support reactive Sets, using array for now
+// TODO: Actually svelte has SvelteSet
 export const hotReloading = $state<string[]>([])
 
 ReloadGUIPointer.subscribe(() => {

--- a/src/ts/sync/multiuser.ts
+++ b/src/ts/sync/multiuser.ts
@@ -6,7 +6,7 @@ import { type Chat } from '../storage/types/chat';
 import { type character } from '../storage/types/character';
 import { selectedCharID } from '../stores.svelte';
 import { sleep } from '../util';
-import { findCharacterIndexbyId } from "../characters";
+import { findCharacterIndexbyId } from "../characters.svelte";
 import type { DataConnection, Peer } from 'peerjs';
 import { readImage } from '../globalApi.svelte';
 import { doingChat } from '../process/index.svelte';


### PR DESCRIPTION
# Description
## Summary

This PR migrates legacy Svelte `writable` stores to Svelte 5's native `$state` runes pattern. The migration consolidates scattered individual stores into cohesive state objects, improving code organization and preparing the codebase for Svelte 5 compatibility.

## Motivation

- **Svelte 5 Compatibility**: Svelte 5 introduces runes (`$state`, `$derived`, etc.) as the recommended reactive primitive, deprecating the store-based approach
- **Code Organization**: Individual `writable` stores were scattered across multiple files, making state management difficult to track
- **Reduced Boilerplate**: `$state` objects eliminate the need for `.subscribe()`, `.set()`, and `.update()` patterns

## Changes Overview

### File Renames
Files containing `$state` runes are renamed from `.ts` to `.svelte.ts` to enable Svelte's rune compilation:
- `bootstrap.ts` → `svelte.ts`
- `characters.ts` → `characters.svelte.ts`
- `characterCards.ts` → `characterCards.svelte.ts`
- `hypav3.ts` → `hypav3.svelte.ts`
- `hotkey.ts` → `hotkey.svelte.ts`

### State Consolidation

| New State Object | Consolidated Stores |
|------------------|---------------------|
| `sideBarState` | `sideBarStore`, `sideBarClosing` |
| `modalState` | `openPresetList`, `openPersonaList`, `bookmarkListOpen` |
| `hypaV3State` | `hypaV3ModalOpen`, `hypaV3ProgressStore` |
| `realmState` | `OpenRealmStore`, `RealmInitialOpenChar`, `ShowRealmFrameStore` |
| `appState` | `loadedStore` |
| `layoutState` | `SizeState`, `DynamicGUI`, `MobileGUI`, `MobileGUIStack`, `MobileSideBar`, `ShowVN`, `MobileSearch` |

### Migration Pattern
```typescript
// Before: Individual writable stores
export const sideBarStore = writable(false)
export const sideBarClosing = writable(false)

// After: Consolidated $state object
export const sideBarState = $state({
  open: false,
  closing: false
})
```

## Commits

1. **7db94ac9** - Migrate `sideBarStore` and `sideBarClosing` to `$state`
2. **2cb69653** - Migrate hotkey to svelte.ts and consolidate modal stores to `modalState`
3. **4a267fcc** - Migrate hypav3 to svelte.ts and consolidate hypaV3 stores to `hypaV3State`
4. **0cc72869** - Add TODO comment for SvelteSet migration
5. **2469afa0** - Migrate `SizeStore` to `SizeState` `$state`
6. **8e1779e4** - Migrate characters/characterCards to svelte.ts, consolidate Realm stores to `realmState`
7. **5ae7818f** - Migrate `loadedStore` to `appState` and rename bootstrap to svelte.ts
8. **fcda85ea** - Consolidate `DynamicGUI` and `SizeState` into `layoutState`
9. **31c763e2** - Migrate Mobile GUI stores to `layoutState` runes

## Notes

- `MobileSearch` store was removed and refactored to pass search state directly between components via props instead of relying on a global store
- TODO: Investigate whether `SvelteSet` can be used for set-based reactive state (added in commit 0cc72869)