### PR TITLE
perf: module import speed

### DIFF
--- a/src/ts/process/modules.ts
+++ b/src/ts/process/modules.ts
@@ -1,7 +1,7 @@
 import { language } from "src/lang"
 import { alertConfirm, alertError, alertModuleSelect, alertNormal, alertStore } from "../alert"
 import { getCurrentCharacter, getCurrentChat, getDatabase, setCurrentCharacter, setDatabase, type customscript, type loreBook, type triggerscript } from "../storage/database.svelte"
-import { AppendableBuffer, downloadFile, readImage, saveAsset } from "../globalApi.svelte"
+import { AppendableBuffer, downloadFile, forageStorage, readImage, saveAsset } from "../globalApi.svelte"
 import { isTauri, isNodeServer, isCapacitor } from "src/ts/platform"
 import { selectSingleFile, sleep } from "../util"
 import { v4 } from "uuid"
@@ -158,9 +158,6 @@ export async function readModule(buf:Buffer):Promise<RisuModule> {
             type: 'wait',
             msg: `Loading... (Adding Assets ${i} / ${module.assets.length})`
         })
-        if(!isTauri && !isCapacitor &&!isNodeServer){
-            await sleep(100)
-        }
         i++
     }
     alertStore.set({

--- a/src/ts/process/processzip.ts
+++ b/src/ts/process/processzip.ts
@@ -1,6 +1,6 @@
 import { AppendableBuffer, saveAsset, type LocalWriter, type VirtualWriter } from "../globalApi.svelte";
 import * as fflate from "fflate";
-import { asBuffer, sleep } from "../util";
+import { asBuffer, Semaphore, sleep } from "../util";
 import { alertStore } from "../alert";
 import { hasher } from "../parser.svelte";
 import { hubURL } from "../characterCards";
@@ -140,45 +140,6 @@ export class CharXWriter{
         this.apb.clear()
         if(this.writeEnd){
             await this.writer.close()
-        }
-    }
-}
-
-/**
- * Semaphore: Concurrency control mechanism
- *
- * Limits the number of operations that can run simultaneously.
- * When max concurrent operations are running, new operations wait in queue.
- *
- * Example: If max=3, only 3 asset saves can run at once.
- * The 4th save waits until one of the first 3 completes.
- */
-class Semaphore {
-    private available: number
-    private readonly max: number
-    private waiting: Array<() => void> = []
-
-    constructor(max: number) {
-        this.available = max
-        this.max = max
-    }
-
-    async acquire(): Promise<void> {
-        if (this.available > 0) {
-            this.available -= 1
-            return
-        }
-        await new Promise<void>(resolve => this.waiting.push(resolve))
-    }
-
-    release(): void {
-        const next = this.waiting.shift()
-        if (next) {
-            next()
-            return
-        }
-        if (this.available < this.max) {
-            this.available += 1
         }
     }
 }


### PR DESCRIPTION
# Description
## Changes

- Remove unnecessary sleep delay in module asset import
- Parallelize risum asset parsing (max 10 concurrent operations)
- Move `Semaphore` class to util.ts for reuse
- Add retry logic for failed asset saves