### PR TITLE
refactor: clean up buildPrompt and related code

### DIFF
--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -216,8 +216,6 @@ export async function sendChat(chatProcessIndex = -1, arg: {
     /* ========================================
      *       STAGE 1,2: PROMPT BUILDING
      * ======================================== */
-    let workingChat: Chat
-
     const stageTimings = {
         stage1Start: 0,
         stage2Start: 0,
@@ -356,7 +354,8 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         addRerolls(generationId, Object.values(lastResponseChunk))
 
         chatOwner.chats[selectedChatPage] = parseChatCBS(DBState.currentChat, speakingChar)
-        workingChat = DBState.currentChat
+        let workingChat = DBState.currentChat
+
         const triggerResult = await runTrigger(speakingChar, 'output', { chat: workingChat })
         if (triggerResult && triggerResult.chat) {
             workingChat = triggerResult.chat
@@ -444,7 +443,7 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         }
 
         chatOwner.chats[selectedChatPage] = parseChatCBS(DBState.currentChat, speakingChar)
-        workingChat = DBState.currentChat
+        const workingChat = DBState.currentChat
 
         const triggerResult = await runTrigger(speakingChar, 'output', { chat: workingChat })
         if (triggerResult && triggerResult.chat) {

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store"
 import { changeToPreset } from '../storage/preset-manager'
-import { type Chat } from '../storage/types/chat'
+import { type Chat, type MessageGenerationInfo } from '../storage/types/chat'
 import { type character } from '../storage/types/character'
 import { DBState } from '../stores.svelte'
 import { CharEmotion } from "../stores.svelte"
@@ -216,8 +216,25 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         return false
     }
 
-    const { workingChat: _workingChat, promptInfo, stageTimings, formatted: formatted, generationId, generationInfo } = promptResult.data
+    const { workingChat: _workingChat, promptInfo, stageTimings, formatted: formatted, inputTokens, outputTokens } = promptResult.data
     workingChat = _workingChat
+
+    const generationId = v4()
+    const generationModel = getGenerationModelString()
+
+    const generationInfo: MessageGenerationInfo = {
+        model: generationModel,
+        generationId: generationId,
+        inputTokens: inputTokens,
+        outputTokens: outputTokens,
+        maxContext: DBState.db.maxContext,
+        stageTiming: {
+            stage1: stageTimings.stage1Duration,
+            stage2: stageTimings.stage2Duration,
+            stage3: 0,
+            stage4: 0
+        }
+    }
 
     const biases: [string, number][] = DBState.db.bias.concat(speakingChar.bias).map((v) => {
         return [risuChatParser(v[0].replaceAll("\\n", "\n").replaceAll("\\r", "\r").replaceAll("\\\\", "\\"), { chara: speakingChar }), v[1]]

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -36,6 +36,18 @@ export const chatGenState = $state({
 export let previewFormated: OpenAIChat[] = []
 export let previewBody: string = ''
 
+
+export interface StageTimings {
+    stage1Start: number
+    stage2Start: number
+    stage3Start: number
+    stage4Start: number
+    stage1Duration: number
+    stage2Duration: number
+    stage3Duration: number
+    stage4Duration: number
+}
+
 /**
  * Sends a chat message and processes the AI response.
  *
@@ -201,13 +213,23 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         return false
     }
 
-
     /* ========================================
      *       STAGE 1,2: PROMPT BUILDING
      * ======================================== */
     let workingChat: Chat
 
-    const promptResult = await buildPrompt(chatOwner, selectedChatPage, speakingChar, arg)
+    const stageTimings = {
+        stage1Start: 0,
+        stage2Start: 0,
+        stage3Start: 0,
+        stage4Start: 0,
+        stage1Duration: 0,
+        stage2Duration: 0,
+        stage3Duration: 0,
+        stage4Duration: 0
+    }
+
+    const promptResult = await buildPrompt(chatOwner, selectedChatPage, speakingChar, stageTimings, arg.continue)
     if (!promptResult.success) {
         const errorMsg = ('error' in promptResult && promptResult.error)
             ? promptResult.error
@@ -216,8 +238,7 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         return false
     }
 
-    const { workingChat: _workingChat, promptInfo, stageTimings, formatted: formatted, inputTokens, outputTokens } = promptResult.data
-    workingChat = _workingChat
+    const { finalPrompt, promptInfo, inputTokens, outputTokens } = promptResult.data
 
     const generationId = v4()
     const generationModel = getGenerationModelString()
@@ -246,12 +267,12 @@ export async function sendChat(chatProcessIndex = -1, arg: {
     chatGenState.stage = 3
     stageTimings.stage3Start = Date.now()
     if (arg.preview) {
-        previewFormated = formatted
+        previewFormated = finalPrompt
         return true
     }
 
     const req = await requestChatData({
-        formated: formatted,
+        formated: finalPrompt,
         biasString: biases,
         currentChar: speakingChar,
         useStreaming: true,

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -216,7 +216,7 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         return false
     }
 
-    const { workingChat: _workingChat, promptInfo, stageTimings, formated, generationId, generationInfo } = promptResult.data
+    const { workingChat: _workingChat, promptInfo, stageTimings, formatted: formatted, generationId, generationInfo } = promptResult.data
     workingChat = _workingChat
 
     const biases: [string, number][] = DBState.db.bias.concat(speakingChar.bias).map((v) => {
@@ -229,12 +229,12 @@ export async function sendChat(chatProcessIndex = -1, arg: {
     chatGenState.stage = 3
     stageTimings.stage3Start = Date.now()
     if (arg.preview) {
-        previewFormated = formated
+        previewFormated = formatted
         return true
     }
 
     const req = await requestChatData({
-        formated: formated,
+        formated: formatted,
         biasString: biases,
         currentChar: speakingChar,
         useStreaming: true,

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store"
 import { changeToPreset } from '../storage/preset-manager'
-import { type Chat, type MessageGenerationInfo } from '../storage/types/chat'
+import { type MessageGenerationInfo } from '../storage/types/chat'
 import { type character } from '../storage/types/character'
 import { DBState } from '../stores.svelte'
 import { CharEmotion } from "../stores.svelte"

--- a/src/ts/process/index.svelte.ts
+++ b/src/ts/process/index.svelte.ts
@@ -216,8 +216,12 @@ export async function sendChat(chatProcessIndex = -1, arg: {
         return false
     }
 
-    const { workingChat: _workingChat, promptInfo, stageTimings, formated, biases, generationId, generationInfo } = promptResult.data
+    const { workingChat: _workingChat, promptInfo, stageTimings, formated, generationId, generationInfo } = promptResult.data
     workingChat = _workingChat
+
+    const biases: [string, number][] = DBState.db.bias.concat(speakingChar.bias).map((v) => {
+        return [risuChatParser(v[0].replaceAll("\\n", "\n").replaceAll("\\r", "\r").replaceAll("\\\\", "\\"), { chara: speakingChar }), v[1]]
+    })
 
     /* ========================================
      *       STAGE 3: AI REQUEST

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -46,7 +46,7 @@ interface Stage1_2Output {
         stage3Duration: number,
         stage4Duration: number
     }
-    formated: OpenAIChat[]
+    formatted: OpenAIChat[]
     generationId: string
     generationInfo: MessageGenerationInfo
 }
@@ -970,7 +970,7 @@ export async function buildPrompt(
     }
 
     // Build final formatted prompt array
-    let formated: OpenAIChat[] = []
+    let formatted: OpenAIChat[] = []
 
     // Continue chat model
     if (arg.continue && (DBState.db.aiModel.startsWith('claude') || DBState.db.aiModel.startsWith('gpt') || DBState.db.aiModel.startsWith('openrouter') || DBState.db.aiModel.startsWith('reverse_proxy'))) {
@@ -986,20 +986,20 @@ export async function buildPrompt(
                 continue
             }
             if (!(DBState.db.aiModel.startsWith('gpt') || DBState.db.aiModel.startsWith('claude') || DBState.db.aiModel === 'openrouter' || DBState.db.aiModel === 'reverse_proxy')) {
-                formated.push(chat)
+                formatted.push(chat)
                 continue
             }
             if (chat.role === 'system') {
-                const lastChat = formated.at(-1)
+                const lastChat = formatted.at(-1)
                 if (lastChat && lastChat.role === 'system' && lastChat.memo === chat.memo && lastChat.name === chat.name) {
                     lastChat.content += '\n\n' + chat.content
                 }
                 else {
-                    formated.push(chat)
+                    formatted.push(chat)
                 }
             }
             else {
-                formated.push(chat)
+                formatted.push(chat)
             }
         }
     }
@@ -1134,14 +1134,14 @@ export async function buildPrompt(
                 pushPrompts(chats)
 
                 if (DBState.db.automaticCachePoint && !hasCachePoint) {
-                    let pointer = formated.length - 1
+                    let pointer = formatted.length - 1
                     let depthRemaining = 3
                     while (pointer >= 0) {
                         if (depthRemaining === 0) {
                             break
                         }
-                        if (formated[pointer].role === 'user') {
-                            formated[pointer].cachePoint = true
+                        if (formatted[pointer].role === 'user') {
+                            formatted[pointer].cachePoint = true
                             depthRemaining--
                         }
                         pointer--
@@ -1165,14 +1165,14 @@ export async function buildPrompt(
                 break
             }
             case 'cache': {
-                let pointer = formated.length - 1
+                let pointer = formatted.length - 1
                 let depthRemaining = card.depth
                 while (pointer >= 0) {
                     if (depthRemaining === 0) {
                         break
                     }
-                    if (formated[pointer].role === card.role || card.role === 'all') {
-                        formated[pointer].cachePoint = true
+                    if (formatted[pointer].role === card.role || card.role === 'all') {
+                        formatted[pointer].cachePoint = true
                         depthRemaining--
                     }
                     pointer--
@@ -1182,7 +1182,7 @@ export async function buildPrompt(
         }
     }
 
-    formated = formated.map((v) => {
+    formatted = formatted.map((v) => {
         v.content = v.content.trim()
         return v
     })
@@ -1197,13 +1197,13 @@ export async function buildPrompt(
     // Character depth prompt insertion
     if (speakingChar.depth_prompt && speakingChar.depth_prompt.prompt && speakingChar.depth_prompt.prompt.length > 0) {
         const depthPrompt = speakingChar.depth_prompt
-        formated.splice(formated.length - depthPrompt.depth, 0, {
+        formatted.splice(formatted.length - depthPrompt.depth, 0, {
             role: 'system',
             content: risuChatParser(depthPrompt.prompt, { chara: speakingChar })
         })
     }
 
-    formated = await runLuaEditTrigger(speakingChar, 'editRequest', formated)
+    formatted = await runLuaEditTrigger(speakingChar, 'editRequest', formatted)
 
     if (DBState.db.promptInfoInsideChat && DBState.db.promptTextInfoInsideChat) {
         promptBodyformatedForChatStore = await runLuaEditTrigger(speakingChar, 'editRequest', promptBodyformatedForChatStore)
@@ -1213,23 +1213,23 @@ export async function buildPrompt(
     //token rechecking
     let inputTokens = 0
 
-    for (const chat of formated) {
+    for (const chat of formatted) {
         inputTokens += await tokenizer.tokenizeChat(chat)
     }
 
     if (inputTokens > maxContextTokens) {
         let pointer = 0
         while (inputTokens > maxContextTokens) {
-            if (pointer >= formated.length) {
+            if (pointer >= formatted.length) {
                 return { success: false, error: language.errors.toomuchtoken + "\n\nAt token rechecking. Required Tokens: " + inputTokens }
             }
-            if (formated[pointer].removable) {
-                inputTokens -= await tokenizer.tokenizeChat(formated[pointer])
-                formated[pointer].content = ''
+            if (formatted[pointer].removable) {
+                inputTokens -= await tokenizer.tokenizeChat(formatted[pointer])
+                formatted[pointer].content = ''
             }
             pointer++
         }
-        formated = formated.filter((v) => {
+        formatted = formatted.filter((v) => {
             return v.content !== '' || (v.multimodals && v.multimodals.length > 0)
         })
     }
@@ -1256,5 +1256,5 @@ export async function buildPrompt(
         }
     }
 
-    return { success: true, data: { formated, generationId, generationInfo, promptInfo, stageTimings, workingChat } }
+    return { success: true, data: { formatted, generationId, generationInfo, promptInfo, stageTimings, workingChat } }
 }

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -47,7 +47,6 @@ interface Stage1_2Output {
         stage4Duration: number
     }
     formated: OpenAIChat[]
-    biases: [string, number][]
     generationId: string
     generationInfo: MessageGenerationInfo
 }
@@ -919,10 +918,6 @@ export async function buildPrompt(
     /* ========================================
      *       STAGE 1: PROMPT ASSEMBLY (cont.)
      * ======================================== */
-    const biases: [string, number][] = DBState.db.bias.concat(speakingChar.bias).map((v) => {
-        return [risuChatParser(v[0].replaceAll("\\n", "\n").replaceAll("\\r", "\r").replaceAll("\\\\", "\\"), { chara: speakingChar }), v[1]]
-    })
-
     const memories: OpenAIChat[] = []
 
     promptParts.chats = chats.map((v) => {
@@ -1261,5 +1256,5 @@ export async function buildPrompt(
         }
     }
 
-    return { success: true, data: { biases, formated, generationId, generationInfo, promptInfo, stageTimings, workingChat } }
+    return { success: true, data: { formated, generationId, generationInfo, promptInfo, stageTimings, workingChat } }
 }

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -739,7 +739,7 @@ export async function buildPrompt(
             (chatOwner.type === 'group' && DBState.db.groupOtherBotRole === 'assistant') ||
             (DBState.db.promptSettings.sendName)
         ) {
-            const form = DBState.db.groupTemplate || `<{{char}}\'s Message>\n{{slot}}\n</{{char}}\'s Message>`
+            const form = DBState.db.groupTemplate || `<{{char}}'s Message>\n{{slot}}\n</{{char}}'s Message>`
             formatedChat = risuChatParser(form, { chara: findCharacterbyIdwithCache(msg.saying).name }).replace('{{slot}}', formatedChat)
             switch (DBState.db.groupOtherBotRole) {
                 case 'user':
@@ -855,9 +855,7 @@ export async function buildPrompt(
             chats = sp.chats
             reservedTokens = sp.currentTokens
             workingChat.hypaV2Data = sp.memory ?? workingChat.hypaV2Data
-            DBState.currentChat.hypaV2Data = workingChat.hypaV2Data
 
-            workingChat = DBState.currentChat
             console.log("[Expected to be updated] chat's HypaV2Data: ", workingChat.hypaV2Data)
         }
         else if (DBState.db.hypaV3) {
@@ -867,7 +865,6 @@ export async function buildPrompt(
                 // Save new summary
                 if (sp.memory) {
                     workingChat.hypaV3Data = sp.memory
-                    DBState.currentChat.hypaV3Data = workingChat.hypaV3Data
                 }
                 console.log(sp)
                 return { success: false, error: sp.error }
@@ -875,9 +872,7 @@ export async function buildPrompt(
             chats = sp.chats
             reservedTokens = sp.currentTokens
             workingChat.hypaV3Data = sp.memory ?? workingChat.hypaV3Data
-            DBState.currentChat.hypaV3Data = workingChat.hypaV3Data
 
-            workingChat = DBState.currentChat
             console.log("[Expected to be updated] chat's HypaV3Data: ", workingChat.hypaV3Data)
         }
         else {
@@ -890,7 +885,7 @@ export async function buildPrompt(
             chats = sp.chats
             reservedTokens = sp.currentTokens
             workingChat.supaMemoryData = sp.memory ?? workingChat.supaMemoryData
-            DBState.currentChat.supaMemoryData = workingChat.supaMemoryData
+
             console.log(workingChat.supaMemoryData)
             workingChat.lastMemory = sp.lastId ?? workingChat.lastMemory
         }

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -12,11 +12,12 @@ import type { Chat, Message, MessagePresetInfo } from "../storage/types/chat"
 import { DBState } from "../stores.svelte"
 import { ChatTokenizer } from "../tokenizer"
 import { parseToggleSyntax } from "../utils/util"
+import { parseChatML } from "../parser/chatML"
 
 import { additionalInformations } from "./embedding/addinfo"
 import { exampleMessage } from "./exampleMessages"
 import { getInlayAsset } from "./files/inlays"
-import { chatGenState } from "./index.svelte"
+import { chatGenState, type StageTimings } from "./index.svelte"
 import { findCharacterbyIdwithCache, formatPrompt, parseChatCBS, systemizeChat } from "./index_util.svelte"
 import { loadLoreBookV3Prompt } from "./lorebook.svelte"
 import { hanuraiMemory } from "./memory/hanuraiMemory"
@@ -30,28 +31,17 @@ import { runLuaEditTrigger } from "./scriptings"
 import { runImageEmbedding } from "./transformers"
 import { runTrigger } from "./triggers"
 import type { OpenAIChat, MultiModal } from "./types"
-import { parseChatML } from "../parser/chatML"
 
-interface Stage1_2Output {
-    workingChat: Chat
-    promptInfo: MessagePresetInfo
-    stageTimings: {
-        stage1Start: number,
-        stage2Start: number,
-        stage3Start: number,
-        stage4Start: number,
-        stage1Duration: number,
-        stage2Duration: number,
-        stage3Duration: number,
-        stage4Duration: number
-    }
-    formatted: OpenAIChat[],
+interface BuildPromptOutput {
+    promptInfo: MessagePresetInfo,
+    stageTimings: StageTimings,
+    finalPrompt: OpenAIChat[],
     inputTokens: number,
     outputTokens: number
 }
 
 type BuildPromptResult =
-    | { success: true; data: Stage1_2Output }
+    | { success: true; data: BuildPromptOutput }
     | { success: false; error?: string }
 
 const DEFAULT_PREBUILT_ASSET_COMMAND = `
@@ -173,23 +163,9 @@ export async function buildPrompt(
     chatOwner: character | groupChat,
     selectedChatPage: number,
     speakingChar: character,
-    arg: {
-        continue?: boolean
-        usedContinueTokens?: number
-        preview?: boolean
-        previewPrompt?: boolean
-    }): Promise<BuildPromptResult> {
-
-    const stageTimings = {
-        stage1Start: 0,
-        stage2Start: 0,
-        stage3Start: 0,
-        stage4Start: 0,
-        stage1Duration: 0,
-        stage2Duration: 0,
-        stage3Duration: 0,
-        stage4Duration: 0
-    }
+    stageTimings: StageTimings,
+    continueResponse?: boolean
+): Promise<BuildPromptResult> {
 
     const perChatAdditonalTokens = DBState.db.aiModel.startsWith('gpt') ? 5 : 3
     const tokenizer = new ChatTokenizer(perChatAdditonalTokens, DBState.db.aiModel.startsWith('gpt') ? 'noName' : 'name')
@@ -964,10 +940,10 @@ export async function buildPrompt(
     }
 
     // Build final formatted prompt array
-    let formatted: OpenAIChat[] = []
+    let finalPrompt: OpenAIChat[] = []
 
     // Continue chat model
-    if (arg.continue && (DBState.db.aiModel.startsWith('claude') || DBState.db.aiModel.startsWith('gpt') || DBState.db.aiModel.startsWith('openrouter') || DBState.db.aiModel.startsWith('reverse_proxy'))) {
+    if (continueResponse && (DBState.db.aiModel.startsWith('claude') || DBState.db.aiModel.startsWith('gpt') || DBState.db.aiModel.startsWith('openrouter') || DBState.db.aiModel.startsWith('reverse_proxy'))) {
         promptParts.postEverything.push({
             role: 'system',
             content: '[Continue the last response]'
@@ -980,20 +956,20 @@ export async function buildPrompt(
                 continue
             }
             if (!(DBState.db.aiModel.startsWith('gpt') || DBState.db.aiModel.startsWith('claude') || DBState.db.aiModel === 'openrouter' || DBState.db.aiModel === 'reverse_proxy')) {
-                formatted.push(chat)
+                finalPrompt.push(chat)
                 continue
             }
             if (chat.role === 'system') {
-                const lastChat = formatted.at(-1)
+                const lastChat = finalPrompt.at(-1)
                 if (lastChat && lastChat.role === 'system' && lastChat.memo === chat.memo && lastChat.name === chat.name) {
                     lastChat.content += '\n\n' + chat.content
                 }
                 else {
-                    formatted.push(chat)
+                    finalPrompt.push(chat)
                 }
             }
             else {
-                formatted.push(chat)
+                finalPrompt.push(chat)
             }
         }
     }
@@ -1128,14 +1104,14 @@ export async function buildPrompt(
                 pushPrompts(chats)
 
                 if (DBState.db.automaticCachePoint && !hasCachePoint) {
-                    let pointer = formatted.length - 1
+                    let pointer = finalPrompt.length - 1
                     let depthRemaining = 3
                     while (pointer >= 0) {
                         if (depthRemaining === 0) {
                             break
                         }
-                        if (formatted[pointer].role === 'user') {
-                            formatted[pointer].cachePoint = true
+                        if (finalPrompt[pointer].role === 'user') {
+                            finalPrompt[pointer].cachePoint = true
                             depthRemaining--
                         }
                         pointer--
@@ -1159,14 +1135,14 @@ export async function buildPrompt(
                 break
             }
             case 'cache': {
-                let pointer = formatted.length - 1
+                let pointer = finalPrompt.length - 1
                 let depthRemaining = card.depth
                 while (pointer >= 0) {
                     if (depthRemaining === 0) {
                         break
                     }
-                    if (formatted[pointer].role === card.role || card.role === 'all') {
-                        formatted[pointer].cachePoint = true
+                    if (finalPrompt[pointer].role === card.role || card.role === 'all') {
+                        finalPrompt[pointer].cachePoint = true
                         depthRemaining--
                     }
                     pointer--
@@ -1176,7 +1152,7 @@ export async function buildPrompt(
         }
     }
 
-    formatted = formatted.map((v) => {
+    finalPrompt = finalPrompt.map((v) => {
         v.content = v.content.trim()
         return v
     })
@@ -1191,13 +1167,13 @@ export async function buildPrompt(
     // Character depth prompt insertion
     if (speakingChar.depth_prompt && speakingChar.depth_prompt.prompt && speakingChar.depth_prompt.prompt.length > 0) {
         const depthPrompt = speakingChar.depth_prompt
-        formatted.splice(formatted.length - depthPrompt.depth, 0, {
+        finalPrompt.splice(finalPrompt.length - depthPrompt.depth, 0, {
             role: 'system',
             content: risuChatParser(depthPrompt.prompt, { chara: speakingChar })
         })
     }
 
-    formatted = await runLuaEditTrigger(speakingChar, 'editRequest', formatted)
+    finalPrompt = await runLuaEditTrigger(speakingChar, 'editRequest', finalPrompt)
 
     if (DBState.db.promptInfoInsideChat && DBState.db.promptTextInfoInsideChat) {
         promptBodyformatedForChatStore = await runLuaEditTrigger(speakingChar, 'editRequest', promptBodyformatedForChatStore)
@@ -1207,23 +1183,23 @@ export async function buildPrompt(
     //token rechecking
     let inputTokens = 0
 
-    for (const chat of formatted) {
+    for (const chat of finalPrompt) {
         inputTokens += await tokenizer.tokenizeChat(chat)
     }
 
     if (inputTokens > maxContextTokens) {
         let pointer = 0
         while (inputTokens > maxContextTokens) {
-            if (pointer >= formatted.length) {
+            if (pointer >= finalPrompt.length) {
                 return { success: false, error: language.errors.toomuchtoken + "\n\nAt token rechecking. Required Tokens: " + inputTokens }
             }
-            if (formatted[pointer].removable) {
-                inputTokens -= await tokenizer.tokenizeChat(formatted[pointer])
-                formatted[pointer].content = ''
+            if (finalPrompt[pointer].removable) {
+                inputTokens -= await tokenizer.tokenizeChat(finalPrompt[pointer])
+                finalPrompt[pointer].content = ''
             }
             pointer++
         }
-        formatted = formatted.filter((v) => {
+        finalPrompt = finalPrompt.filter((v) => {
             return v.content !== '' || (v.multimodals && v.multimodals.length > 0)
         })
     }
@@ -1234,5 +1210,5 @@ export async function buildPrompt(
         outputTokens = maxContextTokens - inputTokens
     }
 
-    return { success: true, data: { formatted, inputTokens, outputTokens, promptInfo, stageTimings, workingChat } }
+    return { success: true, data: { finalPrompt, promptInfo, inputTokens, outputTokens, stageTimings } }
 }

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -8,7 +8,7 @@ import { risuChatParser } from "../parser.svelte"
 import { getPersonaPrompt, getUserName } from "../persona"
 import { setCurrentChat } from "../storage/database.svelte"
 import type { character, groupChat } from "../storage/types/character"
-import type { Chat, Message, MessageGenerationInfo, MessagePresetInfo } from "../storage/types/chat"
+import type { Chat, Message, MessagePresetInfo } from "../storage/types/chat"
 import { DBState } from "../stores.svelte"
 import { ChatTokenizer } from "../tokenizer"
 import { parseToggleSyntax } from "../utils/util"
@@ -23,7 +23,6 @@ import { hanuraiMemory } from "./memory/hanuraiMemory"
 import { hypaMemoryV2 } from "./memory/hypav2"
 import { hypaMemoryV3 } from "./memory/hypav3.svelte"
 import { supaMemory } from "./memory/supaMemory"
-import { getGenerationModelString } from "./models/modelString"
 import { getModuleAssets, getModuleToggles } from "./modules"
 import { getAuthorNoteDefaultText, type PromptItem } from "./prompt"
 import { processScript, processScriptFull } from "./scripts"
@@ -46,9 +45,9 @@ interface Stage1_2Output {
         stage3Duration: number,
         stage4Duration: number
     }
-    formatted: OpenAIChat[]
-    generationId: string
-    generationInfo: MessageGenerationInfo
+    formatted: OpenAIChat[],
+    inputTokens: number,
+    outputTokens: number
 }
 
 type BuildPromptResult =
@@ -905,7 +904,7 @@ export async function buildPrompt(
         let skipCount = 0
         while (reservedTokens > maxContextTokens) {
             if (skipCount >= chats.length - 1) {
-                return { success: false, error: language.errors.toomuchtoken + "\n\nRequired Tokens: " + reservedTokens  }
+                return { success: false, error: language.errors.toomuchtoken + "\n\nRequired Tokens: " + reservedTokens }
             }
             reservedTokens -= await tokenizer.tokenizeChat(chats[skipCount])
             skipCount++
@@ -1239,22 +1238,6 @@ export async function buildPrompt(
     if (inputTokens + outputTokens > maxContextTokens) {
         outputTokens = maxContextTokens - inputTokens
     }
-    const generationId = v4()
-    const generationModel = getGenerationModelString()
 
-    const generationInfo: MessageGenerationInfo = {
-        model: generationModel,
-        generationId: generationId,
-        inputTokens: inputTokens,
-        outputTokens: outputTokens,
-        maxContext: maxContextTokens,
-        stageTiming: {
-            stage1: stageTimings.stage1Duration,
-            stage2: stageTimings.stage2Duration,
-            stage3: 0,
-            stage4: 0
-        }
-    }
-
-    return { success: true, data: { formatted, generationId, generationInfo, promptInfo, stageTimings, workingChat } }
+    return { success: true, data: { formatted, inputTokens, outputTokens, promptInfo, stageTimings, workingChat } }
 }

--- a/src/ts/process/index_promptBuild.svelte.ts
+++ b/src/ts/process/index_promptBuild.svelte.ts
@@ -34,7 +34,6 @@ import type { OpenAIChat, MultiModal } from "./types"
 
 interface BuildPromptOutput {
     promptInfo: MessagePresetInfo,
-    stageTimings: StageTimings,
     finalPrompt: OpenAIChat[],
     inputTokens: number,
     outputTokens: number
@@ -43,6 +42,8 @@ interface BuildPromptOutput {
 type BuildPromptResult =
     | { success: true; data: BuildPromptOutput }
     | { success: false; error?: string }
+
+type PromptSection = 'main' | 'jailbreak' | 'chats' | 'lorebook' | 'globalNote' | 'authorNote' | 'lastChat' | 'description' | 'postEverything' | 'personaPrompt'
 
 const DEFAULT_PREBUILT_ASSET_COMMAND = `
 <Image Tag Instruction>Insert HTML image tags between paragraphs based on context.
@@ -197,7 +198,7 @@ export async function buildPrompt(
      * ======================================== */
     chatGenState.stage = 1
     stageTimings.stage1Start = Date.now()
-    const promptParts = {
+    const promptParts: Record<PromptSection, OpenAIChat[]> = {
         'main': ([] as OpenAIChat[]),
         'jailbreak': ([] as OpenAIChat[]),
         'chats': ([] as OpenAIChat[]),
@@ -1210,5 +1211,5 @@ export async function buildPrompt(
         outputTokens = maxContextTokens - inputTokens
     }
 
-    return { success: true, data: { finalPrompt, promptInfo, inputTokens, outputTokens, stageTimings } }
+    return { success: true, data: { finalPrompt, promptInfo, inputTokens, outputTokens } }
 }


### PR DESCRIPTION
# Description
## Summary
- Move biases and generationInfo building from `buildPrompt` to `sendChat`
- Remove redundant `DBState.currentChat` synchronization
- Improve `buildPrompt` interface and naming
- Narrow `workingChat` variable scope
- Remove `stageTimings` from `buildPrompt` return value
- Fix typo: `formated` → `formatted`
