### PR TITLE
fix: CharX import failure for files containing ZIP signature bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,9 @@
   "pnpm": {
     "neverBuiltDependencies": [
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "fflate@0.8.2": "patches/fflate@0.8.2.patch"
+    }
   }
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,113 @@
+# fflate Streaming ZIP Patch
+
+## Problem
+
+fflate's streaming ZIP API always uses **Data Descriptor (bit 3 flag)**, which causes incorrect parsing when streaming decompression encounters signature-like bytes within file data.
+
+### Background
+
+- When bit 3 flag is set in ZIP format, the Local File Header contains 0 for size/crc, and a Data Descriptor is appended after the file data
+- fflate's streaming ZIP compresses data as it receives it, so it cannot know the size in advance and always uses bit 3 flag
+- During streaming decompression, if the Data Descriptor signature (`0x08074b50`) is found within file data, it causes incorrect parsing
+
+## Solution: Two-pass + fflate Patch
+
+### 1. processzip.ts Modification
+
+Pre-compress with `deflateSync` to calculate compressed size, compute CRC with `crc32` function, then set on `ZipPassThrough`:
+
+```typescript
+// CRC32 calculation function
+const crc32Table = (() => {
+    const t = new Int32Array(256);
+    for (let i = 0; i < 256; ++i) {
+        let c = i, k = 9;
+        while (--k) c = ((c & 1) && -306674912) ^ (c >>> 1);
+        t[i] = c;
+    }
+    return t;
+})();
+
+function crc32(data: Uint8Array): number {
+    let crc = -1;
+    for (let i = 0; i < data.length; ++i) {
+        crc = crc32Table[(crc & 255) ^ data[i]] ^ (crc >>> 8);
+    }
+    return ~crc >>> 0;
+}
+
+// Inside write method
+const compressed = compressionLevel === 0
+    ? dat
+    : fflate.deflateSync(dat, { level: compressionLevel })
+const crc = crc32(dat)
+
+const file = new fflate.ZipPassThrough(key) as fflate.ZipPassThrough & {csize?: number}
+file.size = dat.length           // uncompressed size
+file.csize = compressed.length   // compressed size
+file.crc = crc
+file.compression = compressionLevel === 0 ? 0 : 8  // 0 = store, 8 = deflate
+
+this.zip.add(file)
+file.push(compressed, true)
+```
+
+### 2. fflate Patch (pnpm patch)
+
+Two modifications in `patches/fflate@0.8.2.patch`:
+
+#### 2.1 wzh() Call Modification
+
+Use `file.csize` if set to avoid bit 3 flag:
+
+```javascript
+// Before
+wzh(header, 0, file, f, u, -1);
+
+// After
+wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+```
+
+#### 2.2 ZipPassThrough.push() Method Modification
+
+Preserve preset `crc`/`size` instead of overwriting:
+
+```javascript
+ZipPassThrough.prototype.push = function (chunk, final) {
+    if (!this.ondata)
+        err(5);
+    var presetCrc = this.crc;
+    var presetSize = this.size;
+    this.c.p(chunk);
+    if (presetSize === 0) {
+        this.size += chunk.length;
+    }
+    if (final) {
+        if (presetCrc == null) {
+            this.crc = this.c.d();
+        }
+    }
+    this.process(chunk, final || false);
+};
+```
+
+## Result
+
+- size/crc correctly written in Local File Header
+- No Data Descriptor used (bit 3 = 0)
+- Streaming decompression works correctly
+
+## Applying the Patch
+
+1. Ensure `patches/fflate@0.8.2.patch` file exists
+2. Check `patchedDependencies` in `package.json`:
+   ```json
+   {
+     "pnpm": {
+       "patchedDependencies": {
+         "fflate@0.8.2": "patches/fflate@0.8.2.patch"
+       }
+     }
+   }
+   ```
+3. Run `pnpm install` to automatically apply the patch

--- a/patches/fflate@0.8.2.patch
+++ b/patches/fflate@0.8.2.patch
@@ -1,0 +1,170 @@
+diff --git a/esm/browser.js b/esm/browser.js
+index e1a21e982fefc2021cce24909764661ac6e0fd37..3401fcf1fed44e24d2046a0e8ee529e2499ae275 100644
+--- a/esm/browser.js
++++ b/esm/browser.js
+@@ -1927,10 +1927,17 @@ var ZipPassThrough = /*#__PURE__*/ (function () {
+     ZipPassThrough.prototype.push = function (chunk, final) {
+         if (!this.ondata)
+             err(5);
++        var presetCrc = this.crc;
++        var presetSize = this.size;
+         this.c.p(chunk);
+-        this.size += chunk.length;
+-        if (final)
+-            this.crc = this.c.d();
++        if (presetSize === 0) {
++            this.size += chunk.length;
++        }
++        if (final) {
++            if (presetCrc == null) {
++                this.crc = this.c.d();
++            }
++        }
+         this.process(chunk, final || false);
+     };
+     return ZipPassThrough;
+@@ -2046,7 +2053,7 @@ var Zip = /*#__PURE__*/ (function () {
+             if (fl_1 > 65535)
+                 this.ondata(err(11, 0, 1), null, false);
+             var header = new u8(hl_1);
+-            wzh(header, 0, file, f, u, -1);
++            wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+             var chks_1 = [header];
+             var pAll_1 = function () {
+                 for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+diff --git a/esm/index.mjs b/esm/index.mjs
+index 87c11c68699d8cbea29ddb24d240b162932f64bd..bbd3d72078cb144973da85d268809ccbef65e8fd 100644
+--- a/esm/index.mjs
++++ b/esm/index.mjs
+@@ -1941,10 +1941,17 @@ var ZipPassThrough = /*#__PURE__*/ (function () {
+     ZipPassThrough.prototype.push = function (chunk, final) {
+         if (!this.ondata)
+             err(5);
++        var presetCrc = this.crc;
++        var presetSize = this.size;
+         this.c.p(chunk);
+-        this.size += chunk.length;
+-        if (final)
+-            this.crc = this.c.d();
++        if (presetSize === 0) {
++            this.size += chunk.length;
++        }
++        if (final) {
++            if (presetCrc == null) {
++                this.crc = this.c.d();
++            }
++        }
+         this.process(chunk, final || false);
+     };
+     return ZipPassThrough;
+@@ -2060,7 +2067,7 @@ var Zip = /*#__PURE__*/ (function () {
+             if (fl_1 > 65535)
+                 this.ondata(err(11, 0, 1), null, false);
+             var header = new u8(hl_1);
+-            wzh(header, 0, file, f, u, -1);
++            wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+             var chks_1 = [header];
+             var pAll_1 = function () {
+                 for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+diff --git a/lib/browser.cjs b/lib/browser.cjs
+index c7fe934a7490994c7989e6c427006ef6eeae123c..93faf3f63d28153a42016844c67526191b1a394f 100644
+--- a/lib/browser.cjs
++++ b/lib/browser.cjs
+@@ -1946,10 +1946,17 @@ var ZipPassThrough = /*#__PURE__*/ (function () {
+     ZipPassThrough.prototype.push = function (chunk, final) {
+         if (!this.ondata)
+             err(5);
++        var presetCrc = this.crc;
++        var presetSize = this.size;
+         this.c.p(chunk);
+-        this.size += chunk.length;
+-        if (final)
+-            this.crc = this.c.d();
++        if (presetSize === 0) {
++            this.size += chunk.length;
++        }
++        if (final) {
++            if (presetCrc == null) {
++                this.crc = this.c.d();
++            }
++        }
+         this.process(chunk, final || false);
+     };
+     return ZipPassThrough;
+@@ -2065,7 +2072,7 @@ var Zip = /*#__PURE__*/ (function () {
+             if (fl_1 > 65535)
+                 this.ondata(err(11, 0, 1), null, false);
+             var header = new u8(hl_1);
+-            wzh(header, 0, file, f, u, -1);
++            wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+             var chks_1 = [header];
+             var pAll_1 = function () {
+                 for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+diff --git a/lib/index.cjs b/lib/index.cjs
+index 56e09c6de374646a25466b3391eed18686342543..2c00fa5c7ea7e93cac31c1514f1b79bad4f75feb 100644
+--- a/lib/index.cjs
++++ b/lib/index.cjs
+@@ -1926,10 +1926,17 @@ var ZipPassThrough = /*#__PURE__*/ (function () {
+     ZipPassThrough.prototype.push = function (chunk, final) {
+         if (!this.ondata)
+             err(5);
++        var presetCrc = this.crc;
++        var presetSize = this.size;
+         this.c.p(chunk);
+-        this.size += chunk.length;
+-        if (final)
+-            this.crc = this.c.d();
++        if (presetSize === 0) {
++            this.size += chunk.length;
++        }
++        if (final) {
++            if (presetCrc == null) {
++                this.crc = this.c.d();
++            }
++        }
+         this.process(chunk, final || false);
+     };
+     return ZipPassThrough;
+@@ -2045,7 +2052,7 @@ var Zip = /*#__PURE__*/ (function () {
+             if (fl_1 > 65535)
+                 this.ondata(err(11, 0, 1), null, false);
+             var header = new u8(hl_1);
+-            wzh(header, 0, file, f, u, -1);
++            wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+             var chks_1 = [header];
+             var pAll_1 = function () {
+                 for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+diff --git a/lib/node.cjs b/lib/node.cjs
+index 3ff05cde0dc4a31864b3cb0ee9708101565eb217..cfe3962c0e0ad0abd30a579febc314681e2efdf6 100644
+--- a/lib/node.cjs
++++ b/lib/node.cjs
+@@ -1958,10 +1958,17 @@ var ZipPassThrough = /*#__PURE__*/ (function () {
+     ZipPassThrough.prototype.push = function (chunk, final) {
+         if (!this.ondata)
+             err(5);
++        var presetCrc = this.crc;
++        var presetSize = this.size;
+         this.c.p(chunk);
+-        this.size += chunk.length;
+-        if (final)
+-            this.crc = this.c.d();
++        if (presetSize === 0) {
++            this.size += chunk.length;
++        }
++        if (final) {
++            if (presetCrc == null) {
++                this.crc = this.c.d();
++            }
++        }
+         this.process(chunk, final || false);
+     };
+     return ZipPassThrough;
+@@ -2077,7 +2084,7 @@ var Zip = /*#__PURE__*/ (function () {
+             if (fl_1 > 65535)
+                 this.ondata(err(11, 0, 1), null, false);
+             var header = new u8(hl_1);
+-            wzh(header, 0, file, f, u, -1);
++            wzh(header, 0, file, f, u, file.csize != null ? file.csize : -1);
+             var chks_1 = [header];
+             var pAll_1 = function () {
+                 for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  fflate@0.8.2:
+    hash: 173b8afd731b7f0f230efde7643b4f31b1f8e6cd6021a35ecfadfda079e8e924
+    path: patches/fflate@0.8.2.patch
+
 importers:
 
   .:
@@ -127,7 +132,7 @@ importers:
         version: 4.22.1
       fflate:
         specifier: ^0.8.2
-        version: 0.8.2
+        version: 0.8.2(patch_hash=173b8afd731b7f0f230efde7643b4f31b1f8e6cd6021a35ecfadfda079e8e924)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -6174,7 +6179,7 @@ snapshots:
 
   compression-streams-polyfill@0.1.7:
     dependencies:
-      fflate: 0.8.2
+      fflate: 0.8.2(patch_hash=173b8afd731b7f0f230efde7643b4f31b1f8e6cd6021a35ecfadfda079e8e924)
 
   concat-map@0.0.1: {}
 
@@ -6759,7 +6764,7 @@ snapshots:
 
   fflate@0.6.10: {}
 
-  fflate@0.8.2: {}
+  fflate@0.8.2(patch_hash=173b8afd731b7f0f230efde7643b4f31b1f8e6cd6021a35ecfadfda079e8e924): {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/src/ts/process/processzip.ts
+++ b/src/ts/process/processzip.ts
@@ -16,6 +16,25 @@ const MAX_CONCURRENT_ASSET_SAVES = 10;
 const HTTP_STATUS_OK_MIN = 200;
 const HTTP_STATUS_OK_MAX = 300;
 
+// CRC32 lookup table (from fflate implementation)
+const crc32Table = (() => {
+    const t = new Int32Array(256);
+    for (let i = 0; i < 256; ++i) {
+        let c = i, k = 9;
+        while (--k) c = ((c & 1) && -306674912) ^ (c >>> 1);
+        t[i] = c;
+    }
+    return t;
+})();
+
+function crc32(data: Uint8Array): number {
+    let crc = -1;
+    for (let i = 0; i < data.length; ++i) {
+        crc = crc32Table[(crc & 255) ^ data[i]] ^ (crc >>> 8);
+    }
+    return ~crc >>> 0;  // Convert to unsigned
+}
+
 export async function processZip(dataArray: Uint8Array): Promise<string> {
     const unzipped = await new Promise<fflate.Unzipped>((resolve, reject) => {
         fflate.unzip(dataArray, (err, data) => {
@@ -96,17 +115,27 @@ export class CharXWriter{
             dat = data
         }
         this.writeEnd = false
-        const file = new fflate.ZipDeflate(key, {
-            level: level ?? 0
-        });
+
+        // Pre-compress to get size/crc for Local File Header (avoids Data Descriptor)
+        const compressionLevel = level ?? 0
+        const compressed = compressionLevel === 0
+            ? dat
+            : fflate.deflateSync(dat, { level: compressionLevel })
+        const crc = crc32(dat)
+
+        const file = new fflate.ZipPassThrough(key) as fflate.ZipPassThrough & {csize?: number}
+        file.size = dat.length
+        file.csize = compressed.length
+        file.crc = crc
+        file.compression = compressionLevel === 0 ? 0 : 8
+
         this.zip.add(file)
-        file.push(dat, true)
+        file.push(compressed, true)
         await this.writer.write(this.apb.buffer)
         this.apb.clear()
         if(this.writeEnd){
             await this.writer.close()
         }
-        
     }
 
     #sanitizeZipFilename(filename:string) {


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where certain CharX files failed to import. The issue occurred when asset files (typically images) happened to contain byte sequences matching ZIP header signatures, causing the streaming decompressor to misparse the archive.

## Background

Since CharX support was introduced in June 2024, some users have reported that certain CharX files fail to import. After investigation, the root cause was identified: when file data contains bytes that match ZIP header signatures (like `0x08074b50`), the streaming decompression fails.

RisuAI uses fflate for both streaming compression (when exporting) and streaming decompression (when importing). The streaming approach is necessary because some bots contain thousands of assets, and loading everything into memory at once could cause issues.

## The Problem

When fflate creates a ZIP using its streaming API, it doesn't know the file sizes upfront. To handle this, it uses a ZIP feature called "Data Descriptor" (indicated by bit 3 in the general purpose flags). With Data Descriptor enabled, the Local File Header contains zeros for size/CRC fields, and the actual values are written after the file data.

The problem arises during streaming decompression. Since the decompressor doesn't know file sizes from the header, it must scan the data looking for the Data Descriptor signature (`0x08074b50`) to know where each file ends. If the file data itself contains this byte sequence, the decompressor incorrectly thinks it found the end of the file.

## Considered Alternatives

The simplest fix would be to use non-streaming compression or decompression. For example, using `fflate.zipSync()` instead of the streaming API immediately solves the problem because it can write correct sizes in the Local File Header upfront. However, this requires loading all data into memory at once, which is problematic for bots with thousands of assets.

Other options included switching to a different ZIP library or implementing ZIP handling from scratch, but these would require significant changes.

## Solution

This PR patches fflate to allow pre-setting file sizes when using the streaming API. Two changes were made:

**1. processzip.ts modification**

Before adding each file to the ZIP stream, we now pre-compress it with `deflateSync` to calculate the compressed size, and compute the CRC32. These values are set on the `ZipPassThrough` object before calling `push()`.

**2. fflate patch (via pnpm patch)**

The patch modifies fflate to respect preset `csize` (compressed size) values when writing the ZIP header. It also prevents `ZipPassThrough.push()` from overwriting preset CRC and size values.

With these changes, the Local File Header contains correct size/CRC values, so the Data Descriptor is not used (bit 3 = 0). The streaming decompressor can then read file sizes directly from the header instead of scanning for signature bytes.

## Technical Details

The `patches/` folder may be unfamiliar to some contributors. This is pnpm's built-in patching feature that allows modifying dependencies without forking. See `patches/README.md` for details on what was changed in fflate and why.

## Testing

Verified that 1 bot which previously failed to re-import after export now works correctly. Also confirmed that 4 other bots that were already working continue to function normally.
