### PR TITLE
refactor: Fix chat reactivity and scroll issues

### DIFF
--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -6,7 +6,7 @@
     import { createSimpleCharacter, DBState, ReloadChatPointer, selectedCharID } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
     import { get } from 'svelte/store';
-    import { tick } from 'svelte';
+    import { tick, untrack } from 'svelte';
 
     // Get current chat room ID to detect chat switches
     const getCurrentChatRoomId = () => {
@@ -119,31 +119,35 @@
     let previousChatRoomId: string | null = null;
 
     // Auto-scroll when new messages arrive
+    // Tracked: messages.length (triggers effect on new messages)
+    // Untracked: settings, chat room ID, DOM checks (read-only, shouldn't trigger)
     $effect(() => {
-        const currentLength = messages.length;
-        const currentChatRoomId = getCurrentChatRoomId();
-        const isSameChat = currentChatRoomId === previousChatRoomId;
+        const currentLength = messages.length; // <-- TRACKED: triggers on message count change
 
-        // Only auto-scroll if same chat and new messages were added
-        if (isSameChat && currentLength > previousLength) {
-            const lastMsg = messages.at(-1);
-            if (lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage) {
-                const wasAtBottom = checkIfAtBottom();
-                if (wasAtBottom || DBState.db.alwaysScrollToNewMessage) {
-                    // Wait for DOM update then scroll
-                    tick().then(() => {
-                        setTimeout(() => {
-                            scrollToLatestMessage();
-                        }, 100);
-                    });
-                } else {
-                    hasNewUnreadMessage = true;
+        untrack(() => {
+            const currentChatRoomId = getCurrentChatRoomId();
+            const isSameChat = currentChatRoomId === previousChatRoomId;
+
+            // Only auto-scroll if same chat and new messages were added
+            if (isSameChat && currentLength > previousLength) {
+                const lastMsg = messages.at(-1);
+                if (lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage) {
+                    const wasAtBottom = checkIfAtBottom();
+                    if (wasAtBottom || DBState.db.alwaysScrollToNewMessage) {
+                        tick().then(() => {
+                            setTimeout(() => {
+                                scrollToLatestMessage();
+                            }, 100);
+                        });
+                    } else {
+                        hasNewUnreadMessage = true;
+                    }
                 }
             }
-        }
 
-        previousLength = currentLength;
-        previousChatRoomId = currentChatRoomId;
+            previousLength = currentLength;
+            previousChatRoomId = currentChatRoomId;
+        });
     });
 </script>
 

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
     import type { Message } from 'src/ts/storage/types/chat';
     import type { character, groupChat } from 'src/ts/storage/types/character';
-    import { mount, onDestroy, unmount } from 'svelte';
     import Chat from './Chat.svelte';
     import { getCharImage } from 'src/ts/characters.svelte';
-    import { createSimpleCharacter, DBState, selectedCharID, ReloadChatPointer } from 'src/ts/stores.svelte';
+    import { createSimpleCharacter, DBState, ReloadChatPointer } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
     import { get } from 'svelte/store';
-    
-    const getCurrentChatRoomId = () => {
-        const charId = get(selectedCharID);
-        if (charId < 0) return null;
-        const char = DBState.db.characters[charId];
-        if (!char) return null;
-        return char.chats?.[char.chatPage]?.id ?? null;
-    };
+
+    interface VisibleMessage {
+        message: Message;
+        idx: number;
+        reloadPointer: number;
+    }
 
     let {
         messages,
@@ -39,163 +36,87 @@
     } = $props();
 
     let chatBody: HTMLDivElement;
-    let hashes: Set<number> = new Set();
-    let mountInstances: Map<number, {}> = new Map();
 
-    //Non-cryptographic hash function to generate a unique hash for each message
-    function hashCode(str:string):number {
-        let hash = 0;
-        for (let i = 0, len = str.length; i < len; i++) {
-            let chr = str.charCodeAt(i);
-            hash = (hash << 5) - hash + chr;
-            hash |= 0; // Convert to 32bit integer
-        }
-        if(hash == 0){
-            hash = 1; // Ensure hash is not zero
-        }
-        return hash;
-    }
+    // Derived values for rendering
+    const charImage = $derived(getCharImage(currentCharacter.image, 'css'));
+    const userImage = $derived(getCharImage(userIcon, 'css'));
+    const simpleChar = $derived(createSimpleCharacter(currentCharacter));
+    const userLargePortrait = $derived(userIconPortrait ?? false);
+    const charLargePortrait = $derived((currentCharacter as character).largePortrait ?? false);
 
-    const updateChatBody = () => {
-        let nextHash = 0;
-        let currentHashes: Set<number> = new Set();
-        const charImage = getCharImage(currentCharacter.image, 'css')
-        const userImage = getCharImage(userIcon, 'css')
-        const simpleChar = createSimpleCharacter(currentCharacter);
-        let loadStart = messages.length - 1
-        let loadEnd = messages.length - loadPages
-
-        if(chatFoldedStateMessageIndex.index !== -1){
-            loadStart = chatFoldedStateMessageIndex.index
-            loadEnd = Math.max(0, chatFoldedStateMessageIndex.index - loadPages)
-        }
-
+    // Calculate visible messages based on loadPages and foldedState
+    // Data is stored in chronological order (oldest at index 0, newest at end)
+    // Returns messages in display order (oldest first, newest last)
+    const visibleMessages = $derived.by(() => {
         const reloadPointerMap = get(ReloadChatPointer);
 
-        for(let i=loadStart ; i >= loadEnd; i--){
-            if(i < 0) break; // Prevent out of bounds
-            const message = messages[i];
-            const messageLargePortrait = message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false);
-            const reloadPointer = reloadPointerMap[i] ?? 0;
-            let hashd = message.data + (message.chatId ?? '') + i.toString() + messageLargePortrait.toString() + message.disabled?.toString() + reloadPointer.toString();
-            const currentHash = hashCode(hashd);
-            currentHashes.add(currentHash);
-            if(!hashes.has(currentHash)){
-                const b = document.createElement('div');
-                b.setAttribute('x-hashed', currentHash.toString());
-                b.classList.add('chat-message-container');
-                const inst = mount(Chat, {
-                    target: b,
-                    props: {
-                        message: message.data,
-                        isLastMemory: false,
-                        idx: i,
-                        totalLength: messages.length,
-                        img: message.role === 'user' ? userImage : charImage,
-                        onReroll: onReroll,
-                        unReroll: unReroll,
-                        rerollIcon: 'dynamic',
-                        character: simpleChar,
-                        largePortrait: message.role === 'user' ? (userIconPortrait ?? false) : ((currentCharacter as character).largePortrait ?? false),
-                        messageGenerationInfo: message.generationInfo,
-                        role: message.role,
-                        name: message.role === 'user' ? currentUsername : currentCharacter.name,
-                        isComment: message.isComment ?? false,
-                        disabled: message.disabled ?? false,
-                    },
+        let loadStart: number;
+        let loadEnd: number;
 
-                })
-                mountInstances.set(currentHash, inst);
-                const nextElement = document.querySelector(`[x-hashed="${nextHash}"]`);
-                if(nextElement){
-                    chatBody.insertBefore(b, nextElement?.nextSibling);
-                }
-                else{
-                    chatBody.prepend(b);
-                }
-            }
-            nextHash = currentHash;
-            
+        if (chatFoldedStateMessageIndex.index !== -1) {
+            // Folded state - show from fold point to end
+            loadStart = chatFoldedStateMessageIndex.index;
+            loadEnd = messages.length - 1;
+        } else {
+            // Normal state - load most recent N messages (from end of array)
+            loadStart = Math.max(0, messages.length - loadPages);
+            loadEnd = messages.length - 1;
         }
 
-        //@ts-expect-error Set<T> requires type arg, and Set.difference needs 'esnext' lib (polyfilled by Core-js)
-        const toRemove:Set = hashes.difference(currentHashes);
-        toRemove.forEach((hash) => {
-            const inst = mountInstances.get(hash);
-            if(inst){
-                unmount(inst);
-                mountInstances.delete(hash);
-            }
-            const element = chatBody.querySelector(`[x-hashed="${hash}"]`);
-            if(element){
-                chatBody.removeChild(element);
-            }
-        });
+        const result: VisibleMessage[] = [];
+        // Iterate in chronological order (oldest to newest)
+        for (let i = loadStart; i <= loadEnd; i++) {
+            const message = messages[i];
+            if (!message) continue;
+            result.push({
+                message,
+                idx: i,
+                reloadPointer: reloadPointerMap[i] ?? 0
+            });
+        }
+        return result;
+    });
 
-        hashes = currentHashes;
-        
-    };
-
-    onDestroy(() => {
-        console.log('Unmounting Chats');
-        hashes.clear();
-        mountInstances.forEach((inst) => {
-            unmount(inst);
-        });
-        mountInstances.clear();
-    })
-
-    function checkIfAtBottom() {
-        if (!chatBody || !chatBody.parentElement) return true;
-        const sc = chatBody.parentElement;
-        const lastEl = chatBody.firstElementChild;
-        if (!lastEl) return true;
-        const rect = lastEl.getBoundingClientRect();
-        const scRect = sc.getBoundingClientRect();
-        return rect.top <= scRect.bottom + 100;
+    // Generate unique key for each message to trigger re-render when needed
+    function getMessageKey(item: VisibleMessage): string {
+        const { message, idx, reloadPointer } = item;
+        const largePortrait = message.role === 'user' ? userLargePortrait : charLargePortrait;
+        return `${message.chatId ?? ''}-${idx}-${largePortrait}-${message.disabled ?? false}-${reloadPointer}`;
     }
 
     export const scrollToLatestMessage = () => {
-        if(!chatBody) return;
+        if (!chatBody) return;
         hasNewUnreadMessage = false;
-        const element = chatBody.firstElementChild;
-        if(element){
-             element.scrollIntoView({ behavior: 'instant', block: 'start' });
+        const element = chatBody.lastElementChild;
+        if (element) {
+            element.scrollIntoView({ behavior: 'instant', block: 'end' });
         }
     }
-
-    let previousLength = 0;
-    let previousChatRoomId: string | null = null;
-
-    $effect(() => {
-        console.log('Updating Chats');
-        void $ReloadChatPointer; // Make $effect track ReloadChatPointer changes
-        const wasAtBottom = checkIfAtBottom();
-        updateChatBody()
-        
-        const currentChatRoomId = getCurrentChatRoomId();
-        const isSameChat = currentChatRoomId === previousChatRoomId;
-        
-        // Only auto-scroll if it's the same chat and new messages were added
-        if(isSameChat && messages.length > previousLength){
-            const lastMsg = messages.at(-1);
-            if(lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage){
-                if(wasAtBottom || DBState.db.alwaysScrollToNewMessage){
-                    const element = chatBody.firstElementChild;
-                    if(element){
-                        setTimeout(() => {
-                            element.scrollIntoView({ behavior: 'instant', block: 'start' });
-                        }, 700);
-                    }
-                } else {
-                    hasNewUnreadMessage = true;
-                }
-            }
-        }
-        previousLength = messages.length;
-        previousChatRoomId = currentChatRoomId;
-    })
-
 </script>
 
-<div class="flex flex-col-reverse" bind:this={chatBody}></div>
+<div class="flex flex-col" bind:this={chatBody}>
+    {#each visibleMessages as item (getMessageKey(item))}
+        {@const message = item.message}
+        {@const idx = item.idx}
+        {@const isUser = message.role === 'user'}
+        <div class="chat-message-container" data-chat-index={idx}>
+            <Chat
+                message={message.data}
+                isLastMemory={false}
+                {idx}
+                totalLength={messages.length}
+                img={isUser ? userImage : charImage}
+                {onReroll}
+                {unReroll}
+                rerollIcon="dynamic"
+                character={simpleChar}
+                largePortrait={isUser ? userLargePortrait : charLargePortrait}
+                messageGenerationInfo={message.generationInfo}
+                role={message.role}
+                name={isUser ? currentUsername : currentCharacter.name}
+                isComment={message.isComment ?? false}
+                disabled={message.disabled ?? false}
+            />
+        </div>
+    {/each}
+</div>

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -3,19 +3,9 @@
     import type { character, groupChat } from 'src/ts/storage/types/character';
     import Chat from './Chat.svelte';
     import { getCharImage } from 'src/ts/characters.svelte';
-    import { createSimpleCharacter, DBState, ReloadChatPointer, selectedCharID } from 'src/ts/stores.svelte';
+    import { createSimpleCharacter, ReloadChatPointer } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
     import { get } from 'svelte/store';
-    import { tick, untrack } from 'svelte';
-
-    // Get current chat room ID to detect chat switches
-    const getCurrentChatRoomId = () => {
-        const charId = get(selectedCharID);
-        if (charId < 0) return null;
-        const char = DBState.db.characters[charId];
-        if (!char) return null;
-        return char.chats?.[char.chatPage]?.id ?? null;
-    };
 
     interface VisibleMessage {
         message: Message;
@@ -31,8 +21,7 @@
         currentUsername,
         userIcon,
         loadPages,
-        userIconPortrait,
-        hasNewUnreadMessage = $bindable(false)
+        userIconPortrait
     }:{
         messages: Message[]
         currentCharacter: character|groupChat
@@ -42,7 +31,6 @@
         userIcon: string
         loadPages: number
         userIconPortrait?: boolean
-        hasNewUnreadMessage?: boolean
     } = $props();
 
     let chatBody: HTMLDivElement;
@@ -94,61 +82,10 @@
         return `${message.chatId ?? ''}-${idx}-${largePortrait}-${message.disabled ?? false}-${reloadPointer}`;
     }
 
-    export const scrollToLatestMessage = () => {
-        if (!chatBody) return;
-        hasNewUnreadMessage = false;
-        const element = chatBody.lastElementChild;
-        if (element) {
-            element.scrollIntoView({ behavior: 'instant', block: 'end' });
-        }
+    // Expose chatBody for parent to access for scrolling
+    export function getLastMessageElement(): Element | null {
+        return chatBody?.lastElementChild ?? null;
     }
-
-    // Check if user is scrolled to bottom
-    function checkIfAtBottom(): boolean {
-        if (!chatBody || !chatBody.parentElement) return true;
-        const scrollContainer = chatBody.parentElement;
-        const lastEl = chatBody.lastElementChild;
-        if (!lastEl) return true;
-        const rect = lastEl.getBoundingClientRect();
-        const containerRect = scrollContainer.getBoundingClientRect();
-        return rect.bottom <= containerRect.bottom + 100;
-    }
-
-    // Track state for auto-scroll
-    let previousLength = 0;
-    let previousChatRoomId: string | null = null;
-
-    // Auto-scroll when new messages arrive
-    // Tracked: messages.length (triggers effect on new messages)
-    // Untracked: settings, chat room ID, DOM checks (read-only, shouldn't trigger)
-    $effect(() => {
-        const currentLength = messages.length; // <-- TRACKED: triggers on message count change
-
-        untrack(() => {
-            const currentChatRoomId = getCurrentChatRoomId();
-            const isSameChat = currentChatRoomId === previousChatRoomId;
-
-            // Only auto-scroll if same chat and new messages were added
-            if (isSameChat && currentLength > previousLength) {
-                const lastMsg = messages.at(-1);
-                if (lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage) {
-                    const wasAtBottom = checkIfAtBottom();
-                    if (wasAtBottom || DBState.db.alwaysScrollToNewMessage) {
-                        tick().then(() => {
-                            setTimeout(() => {
-                                scrollToLatestMessage();
-                            }, 100);
-                        });
-                    } else {
-                        hasNewUnreadMessage = true;
-                    }
-                }
-            }
-
-            previousLength = currentLength;
-            previousChatRoomId = currentChatRoomId;
-        });
-    });
 </script>
 
 <div class="flex flex-col" bind:this={chatBody}>

--- a/src/lib/ChatScreens/Chats.svelte
+++ b/src/lib/ChatScreens/Chats.svelte
@@ -3,9 +3,19 @@
     import type { character, groupChat } from 'src/ts/storage/types/character';
     import Chat from './Chat.svelte';
     import { getCharImage } from 'src/ts/characters.svelte';
-    import { createSimpleCharacter, DBState, ReloadChatPointer } from 'src/ts/stores.svelte';
+    import { createSimpleCharacter, DBState, ReloadChatPointer, selectedCharID } from 'src/ts/stores.svelte';
     import { chatFoldedStateMessageIndex } from 'src/ts/globalApi.svelte';
     import { get } from 'svelte/store';
+    import { tick } from 'svelte';
+
+    // Get current chat room ID to detect chat switches
+    const getCurrentChatRoomId = () => {
+        const charId = get(selectedCharID);
+        if (charId < 0) return null;
+        const char = DBState.db.characters[charId];
+        if (!char) return null;
+        return char.chats?.[char.chatPage]?.id ?? null;
+    };
 
     interface VisibleMessage {
         message: Message;
@@ -92,6 +102,49 @@
             element.scrollIntoView({ behavior: 'instant', block: 'end' });
         }
     }
+
+    // Check if user is scrolled to bottom
+    function checkIfAtBottom(): boolean {
+        if (!chatBody || !chatBody.parentElement) return true;
+        const scrollContainer = chatBody.parentElement;
+        const lastEl = chatBody.lastElementChild;
+        if (!lastEl) return true;
+        const rect = lastEl.getBoundingClientRect();
+        const containerRect = scrollContainer.getBoundingClientRect();
+        return rect.bottom <= containerRect.bottom + 100;
+    }
+
+    // Track state for auto-scroll
+    let previousLength = 0;
+    let previousChatRoomId: string | null = null;
+
+    // Auto-scroll when new messages arrive
+    $effect(() => {
+        const currentLength = messages.length;
+        const currentChatRoomId = getCurrentChatRoomId();
+        const isSameChat = currentChatRoomId === previousChatRoomId;
+
+        // Only auto-scroll if same chat and new messages were added
+        if (isSameChat && currentLength > previousLength) {
+            const lastMsg = messages.at(-1);
+            if (lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage) {
+                const wasAtBottom = checkIfAtBottom();
+                if (wasAtBottom || DBState.db.alwaysScrollToNewMessage) {
+                    // Wait for DOM update then scroll
+                    tick().then(() => {
+                        setTimeout(() => {
+                            scrollToLatestMessage();
+                        }, 100);
+                    });
+                } else {
+                    hasNewUnreadMessage = true;
+                }
+            }
+        }
+
+        previousLength = currentLength;
+        previousChatRoomId = currentChatRoomId;
+    });
 </script>
 
 <div class="flex flex-col" bind:this={chatBody}>

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -99,6 +99,10 @@
     // Component instance reference
     let chatsInstance: any = $state() // Reference to Chats component for scroll control
 
+    // Scroll container references
+    let outerScrollContainer: HTMLDivElement
+    let innerScrollContainer: HTMLDivElement
+
     // Bind props with defaults
     let { openModuleList = $bindable(false), openChatList = $bindable(false), customStyle = "" }: Props = $props()
 
@@ -129,7 +133,7 @@
      * Check if user is scrolled to bottom of chat
      */
     function checkIfAtBottom(): boolean {
-        const scrollContainer = document.querySelector('.default-chat-screen')
+        const scrollContainer = DBState.db.fixedChatTextarea ? innerScrollContainer : outerScrollContainer
         if (!scrollContainer) return true
         const lastEl = chatsInstance?.getLastMessageElement()
         if (!lastEl) return true
@@ -590,11 +594,13 @@
         <!-- fixedChatTextarea: true = input fixed, false = all scrolls -->
         <!-- ======================================================== -->
         <div
+            bind:this={outerScrollContainer}
             class="h-full w-full flex flex-col relative {DBState.db.fixedChatTextarea ? '' : 'overflow-y-auto'}"
             onscroll={DBState.db.fixedChatTextarea ? undefined : handleChatScroll}
         >
             <!-- Messages area: scrollable when fixed, part of parent scroll when not -->
             <div
+                bind:this={innerScrollContainer}
                 class="flex flex-col relative {DBState.db.fixedChatTextarea ? 'flex-1 overflow-y-auto' : ''} default-chat-screen"
                 onscroll={DBState.db.fixedChatTextarea ? handleChatScroll : undefined}
             >

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -139,6 +139,23 @@
     }
 
     /**
+     * Handles scroll events for infinite scroll and new message button
+     */
+    function handleChatScroll(e: Event) {
+        const chatTarget = e.target as HTMLElement
+        // Infinite scroll: load more messages when near top
+        if (chatTarget.scrollTop < 100 && DBState.currentChat.message.length > loadPages) {
+            loadPages += 15
+        }
+        // Hide "new message" button when scrolled to bottom
+        const lastEl = chatTarget.lastElementChild
+        const isAtBottom = lastEl ? lastEl.getBoundingClientRect().bottom <= chatTarget.getBoundingClientRect().bottom + 100 : true
+        if (isAtBottom) {
+            showNewMessageButton = false
+        }
+    }
+
+    /**
      * Get current chat room ID to detect chat switches
      */
     function getCurrentChatRoomId(): string | null {
@@ -570,27 +587,17 @@
     {:else}
         <!-- ======================================================== -->
         <!-- CHAT CONTAINER                                           -->
-        <!-- Main scrollable area containing all chat messages        -->
-        <!-- Uses flex-col for top-to-bottom message display           -->
+        <!-- fixedChatTextarea: true = input fixed, false = all scrolls -->
         <!-- ======================================================== -->
         <div
-            class="h-full w-full flex flex-col overflow-y-auto relative default-chat-screen"
-            onscroll={(e) => {
-                // Infinite scroll: load more messages when near top
-                const chatTarget = e.target as HTMLElement
-                if (chatTarget.scrollTop < 100 && DBState.currentChat.message.length > loadPages) {
-                    loadPages += 15
-                }
-
-                // Hide "new message" button when scrolled to bottom
-                const chatsContainer = DBState.db.fixedChatTextarea && chatTarget.children[1] ? chatTarget.children[1] : chatTarget.children[0]
-                const lastEl = chatsContainer?.lastElementChild // Newest message is now at the end
-                const isAtBottom = lastEl ? lastEl.getBoundingClientRect().bottom <= chatTarget.getBoundingClientRect().bottom + 100 : true
-                if (isAtBottom) {
-                    showNewMessageButton = false
-                }
-            }}
+            class="h-full w-full flex flex-col relative {DBState.db.fixedChatTextarea ? '' : 'overflow-y-auto'}"
+            onscroll={DBState.db.fixedChatTextarea ? undefined : handleChatScroll}
         >
+            <!-- Messages area: scrollable when fixed, part of parent scroll when not -->
+            <div
+                class="flex flex-col relative {DBState.db.fixedChatTextarea ? 'flex-1 overflow-y-auto' : ''} default-chat-screen"
+                onscroll={DBState.db.fixedChatTextarea ? handleChatScroll : undefined}
+            >
             <!-- ======================================================== -->
             <!-- CHAT MESSAGES SECTION                                    -->
             <!-- Displays all chat messages and handles cold storage      -->
@@ -702,16 +709,19 @@
                     {userIconPortrait}
                 />
             {/if}
+            </div>
+            <!-- End of messages area -->
+
+            <!-- Spacer: pushes input to bottom when messages don't fill screen (only when not fixed) -->
+            {#if !DBState.db.fixedChatTextarea}
+                <div class="flex-1"></div>
+            {/if}
 
             <!-- ======================================================== -->
             <!-- MESSAGE INPUT AREA                                       -->
             <!-- Contains textarea, send button, and menu button          -->
-            <!-- Can be sticky (fixed at bottom) or inline                -->
             <!-- ======================================================== -->
-            <div
-                class="{DBState.db.fixedChatTextarea ? 'sticky pt-2 pb-2 right-0 bottom-0 bg-bgcolor' : 'mt-2 mb-2'} flex items-stretch w-full"
-                style={DBState.db.fixedChatTextarea ? "z-index:29;" : ""}
-            >
+            <div class="{DBState.db.fixedChatTextarea ? 'shrink-0 bg-bgcolor' : ''} pt-2 pb-2 flex items-stretch w-full">
                 <!-- Sticker toggle button (for non-group chats) -->
                 {#if DBState.db.useChatSticker && currentCharacter.type !== "group"}
                     <div

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -49,7 +49,7 @@
     import { DBState } from "src/ts/stores.svelte"
 
     // Svelte utilities
-    import { tick, onDestroy } from "svelte"
+    import { tick, onDestroy, untrack } from "svelte"
 
     // Chat runtime controller
     import { chatRuntime } from "../../ts/chat/chatRuntimeController.svelte"
@@ -118,8 +118,72 @@
      * Scrolls to the latest (bottom-most) message in the chat
      */
     function scrollToBottom() {
-        chatsInstance?.scrollToLatestMessage()
+        showNewMessageButton = false
+        const element = chatsInstance?.getLastMessageElement()
+        if (element) {
+            element.scrollIntoView({ behavior: 'instant', block: 'end' })
+        }
     }
+
+    /**
+     * Check if user is scrolled to bottom of chat
+     */
+    function checkIfAtBottom(): boolean {
+        const scrollContainer = document.querySelector('.default-chat-screen')
+        if (!scrollContainer) return true
+        const lastEl = chatsInstance?.getLastMessageElement()
+        if (!lastEl) return true
+        const rect = lastEl.getBoundingClientRect()
+        const containerRect = scrollContainer.getBoundingClientRect()
+        return rect.bottom <= containerRect.bottom + 100
+    }
+
+    /**
+     * Get current chat room ID to detect chat switches
+     */
+    function getCurrentChatRoomId(): string | null {
+        const charId = $selectedCharID
+        if (charId < 0) return null
+        const char = DBState.db.characters[charId]
+        if (!char) return null
+        return char.chats?.[char.chatPage]?.id ?? null
+    }
+
+    // Track state for auto-scroll
+    let previousMessageLength = 0
+    let previousChatRoomId: string | null = null
+
+    // Auto-scroll when new messages arrive
+    // Tracked: currentChat.length (triggers effect on new messages)
+    // Untracked: settings, chat room ID, DOM checks (read-only, shouldn't trigger)
+    $effect(() => {
+        const currentLength = currentChat.length // <-- TRACKED: triggers on message count change
+
+        untrack(() => {
+            const currentChatRoomId = getCurrentChatRoomId()
+            const isSameChat = currentChatRoomId === previousChatRoomId
+
+            // Only auto-scroll if same chat and new messages were added
+            if (isSameChat && currentLength > previousMessageLength) {
+                const lastMsg = currentChat.at(-1)
+                if (lastMsg && lastMsg.role === 'char' && DBState.db.autoScrollToNewMessage) {
+                    const wasAtBottom = checkIfAtBottom()
+                    if (wasAtBottom || DBState.db.alwaysScrollToNewMessage) {
+                        tick().then(() => {
+                            setTimeout(() => {
+                                scrollToBottom()
+                            }, 100)
+                        })
+                    } else {
+                        showNewMessageButton = true
+                    }
+                }
+            }
+
+            previousMessageLength = currentLength
+            previousChatRoomId = currentChatRoomId
+        })
+    })
 
     // Watch for external scroll requests (e.g., from search results)
     $effect(() => {
@@ -636,7 +700,6 @@
                     {currentUsername}
                     {userIcon}
                     {userIconPortrait}
-                    bind:hasNewUnreadMessage={showNewMessageButton}
                 />
             {/if}
 

--- a/src/lib/ChatScreens/DefaultChatScreen.svelte
+++ b/src/lib/ChatScreens/DefaultChatScreen.svelte
@@ -507,28 +507,139 @@
         <!-- ======================================================== -->
         <!-- CHAT CONTAINER                                           -->
         <!-- Main scrollable area containing all chat messages        -->
-        <!-- Uses flex-col-reverse for bottom-to-top message display  -->
+        <!-- Uses flex-col for top-to-bottom message display           -->
         <!-- ======================================================== -->
         <div
-            class="h-full w-full flex flex-col-reverse overflow-y-auto relative default-chat-screen"
+            class="h-full w-full flex flex-col overflow-y-auto relative default-chat-screen"
             onscroll={(e) => {
                 // Infinite scroll: load more messages when near top
-                //@ts-expect-error scrollHeight/clientHeight/scrollTop don't exist on EventTarget, but target is HTMLElement here
-                const scrolled = e.target.scrollHeight - e.target.clientHeight + e.target.scrollTop
-                if (scrolled < 100 && DBState.currentChat.message.length > loadPages) {
+                const chatTarget = e.target as HTMLElement
+                if (chatTarget.scrollTop < 100 && DBState.currentChat.message.length > loadPages) {
                     loadPages += 15
                 }
 
                 // Hide "new message" button when scrolled to bottom
-                const chatTarget = e.target as HTMLElement
                 const chatsContainer = DBState.db.fixedChatTextarea && chatTarget.children[1] ? chatTarget.children[1] : chatTarget.children[0]
-                const lastEl = chatsContainer?.firstElementChild
-                const isAtBottom = lastEl ? lastEl.getBoundingClientRect().top <= chatTarget.getBoundingClientRect().bottom + 100 : true
+                const lastEl = chatsContainer?.lastElementChild // Newest message is now at the end
+                const isAtBottom = lastEl ? lastEl.getBoundingClientRect().bottom <= chatTarget.getBoundingClientRect().bottom + 100 : true
                 if (isAtBottom) {
                     showNewMessageButton = false
                 }
             }}
         >
+            <!-- ======================================================== -->
+            <!-- CHAT MESSAGES SECTION                                    -->
+            <!-- Displays all chat messages and handles cold storage      -->
+            <!-- ======================================================== -->
+
+            <!-- Handle cold storage (archived chats that need loading) -->
+            {#if DBState.currentChat.message?.[0]?.data?.startsWith(coldStorageHeader)}
+                {#await preLoadChat($selectedCharID, DBState.currentChar.chatPage)}
+                    <div class="w-full flex justify-center text-textcolor2 italic mb-12">
+                        {language.loadingChatData}
+                    </div>
+                {:then a}
+                    <div></div>
+                {/await}
+            {:else}
+                <!-- Load more button for folded/hidden older messages -->
+                {#if chatFoldedStateMessageIndex.index !== -1}
+                    <button class="w-full flex justify-center max-w-full p-4">
+                        <Button
+                            className="max-w-xl w-full"
+                            onclick={() => {
+                                loadPages += chatFoldedStateMessageIndex.index + 1
+                                chatFoldedState.data = null
+                            }}
+                        >
+                            {language.loadMore}
+                        </Button>
+                    </button>
+                {/if}
+
+                <!-- ======================================================== -->
+                <!-- FIRST MESSAGE / GREETING SECTION                         -->
+                <!-- Order: Creator's comment -> AI warning -> First message  -->
+                <!-- ======================================================== -->
+                {#if DBState.currentChat.message.length <= loadPages}
+                    {#if DBState.currentChar.type !== "group"}
+                        <!-- Creator notes/quote display (shown first/top) -->
+                        {#if !DBState.currentChar.removedQuotes && DBState.currentChar.creatorNotes.length >= 2}
+                            <CreatorQuote
+                                quote={DBState.currentChar.creatorNotes}
+                                onRemove={() => {
+                                    const cha = DBState.currentChar
+                                    if (cha.type !== "group") {
+                                        cha.removedQuotes = true
+                                    }
+                                }}
+                            />
+                        {/if}
+                        <!-- AI generation warning for applicable regions -->
+                        {#if aiLawApplies() && DBState.currentChat.message.length === 0}
+                            <div class="ml-auto mr-auto mt-4 text-textcolor2 italic max-w-2/3 wrap-break-word text-center">
+                                {language.aiGenerationWarning}
+                            </div>
+                        {/if}
+                        <!-- First message / greeting (shown after creator comment and AI warning) -->
+                        <Chat
+                            character={createSimpleCharacter(DBState.currentChar)}
+                            name={DBState.currentChar.name}
+                            message={DBState.currentChat.fmIndex === -1
+                                ? DBState.currentChar.firstMessage
+                                : DBState.currentChar.alternateGreetings[DBState.currentChat.fmIndex]}
+                            role="char"
+                            img={getCharImage(DBState.currentChar.image, "css")}
+                            idx={-1}
+                            altGreeting={DBState.currentChar.alternateGreetings.length > 0}
+                            largePortrait={DBState.currentChar.largePortrait}
+                            firstMessage={true}
+                            onReroll={() => {
+                                // Cycle forward through alternate greetings
+                                const cha = DBState.currentChar
+                                const chat = DBState.currentChat
+                                if (cha.type !== "group") {
+                                    if (chat.fmIndex >= cha.alternateGreetings.length - 1) {
+                                        chat.fmIndex = -1
+                                    } else {
+                                        chat.fmIndex += 1
+                                    }
+                                }
+                            }}
+                            unReroll={() => {
+                                // Cycle backward through alternate greetings
+                                const cha = DBState.currentChar
+                                const chat = DBState.currentChat
+                                if (cha.type !== "group") {
+                                    if (chat.fmIndex === -1) {
+                                        chat.fmIndex = cha.alternateGreetings.length - 1
+                                    } else {
+                                        chat.fmIndex -= 1
+                                    }
+                                }
+                            }}
+                            isLastMemory={false}
+                            currentPage={(DBState.currentChat.fmIndex ?? -1) + 2}
+                            totalPages={DBState.currentChar.alternateGreetings.length + 1}
+                        />
+                    {/if}
+                {/if}
+
+                <!-- Main chat messages list component -->
+                <Chats
+                    bind:this={chatsInstance}
+                    messages={currentChat}
+                    {loadPages}
+                    onReroll={() => chatRuntime.reroll()}
+                    unReroll={() => chatRuntime.unReroll()}
+                    {currentCharacter}
+                    {currentUsername}
+                    {userIcon}
+                    {userIconPortrait}
+                    bind:hasNewUnreadMessage={showNewMessageButton}
+                />
+            {/if}
+
             <!-- ======================================================== -->
             <!-- MESSAGE INPUT AREA                                       -->
             <!-- Contains textarea, send button, and menu button          -->
@@ -765,119 +876,6 @@
                         }}
                     />
                 </div>
-            {/if}
-
-            <!-- ======================================================== -->
-            <!-- CHAT MESSAGES SECTION                                    -->
-            <!-- Displays all chat messages and handles cold storage      -->
-            <!-- ======================================================== -->
-
-            <!-- Handle cold storage (archived chats that need loading) -->
-            {#if DBState.currentChat.message?.[0]?.data?.startsWith(coldStorageHeader)}
-                {#await preLoadChat($selectedCharID, DBState.currentChar.chatPage)}
-                    <div class="w-full flex justify-center text-textcolor2 italic mb-12">
-                        {language.loadingChatData}
-                    </div>
-                {:then a}
-                    <div></div>
-                {/await}
-            {:else}
-                <!-- Load more button for folded/hidden older messages -->
-                {#if chatFoldedStateMessageIndex.index !== -1}
-                    <button class="w-full flex justify-center max-w-full p-4">
-                        <Button
-                            className="max-w-xl w-full"
-                            onclick={() => {
-                                loadPages += chatFoldedStateMessageIndex.index + 1
-                                chatFoldedState.data = null
-                            }}
-                        >
-                            {language.loadMore}
-                        </Button>
-                    </button>
-                {/if}
-
-                <!-- Main chat messages list component -->
-                <Chats
-                    bind:this={chatsInstance}
-                    messages={currentChat}
-                    {loadPages}
-                    onReroll={() => chatRuntime.reroll()}
-                    unReroll={() => chatRuntime.unReroll()}
-                    {currentCharacter}
-                    {currentUsername}
-                    {userIcon}
-                    {userIconPortrait}
-                    bind:hasNewUnreadMessage={showNewMessageButton}
-                />
-
-                <!-- ======================================================== -->
-                <!-- FIRST MESSAGE / GREETING                                 -->
-                <!-- Shows character's initial greeting (not stored in chat)  -->
-                <!-- Supports alternate greetings with reroll navigation      -->
-                <!-- ======================================================== -->
-                {#if DBState.currentChat.message.length <= loadPages}
-                    {#if DBState.currentChar.type !== "group"}
-                        <Chat
-                            character={createSimpleCharacter(DBState.currentChar)}
-                            name={DBState.currentChar.name}
-                            message={DBState.currentChat.fmIndex === -1
-                                ? DBState.currentChar.firstMessage
-                                : DBState.currentChar.alternateGreetings[DBState.currentChat.fmIndex]}
-                            role="char"
-                            img={getCharImage(DBState.currentChar.image, "css")}
-                            idx={-1}
-                            altGreeting={DBState.currentChar.alternateGreetings.length > 0}
-                            largePortrait={DBState.currentChar.largePortrait}
-                            firstMessage={true}
-                            onReroll={() => {
-                                // Cycle forward through alternate greetings
-                                const cha = DBState.currentChar
-                                const chat = DBState.currentChat
-                                if (cha.type !== "group") {
-                                    if (chat.fmIndex >= cha.alternateGreetings.length - 1) {
-                                        chat.fmIndex = -1
-                                    } else {
-                                        chat.fmIndex += 1
-                                    }
-                                }
-                            }}
-                            unReroll={() => {
-                                // Cycle backward through alternate greetings
-                                const cha = DBState.currentChar
-                                const chat = DBState.currentChat
-                                if (cha.type !== "group") {
-                                    if (chat.fmIndex === -1) {
-                                        chat.fmIndex = cha.alternateGreetings.length - 1
-                                    } else {
-                                        chat.fmIndex -= 1
-                                    }
-                                }
-                            }}
-                            isLastMemory={false}
-                            currentPage={(DBState.currentChat.fmIndex ?? -1) + 2}
-                            totalPages={DBState.currentChar.alternateGreetings.length + 1}
-                        />
-                        <!-- AI generation warning for applicable regions -->
-                        {#if aiLawApplies() && DBState.currentChat.message.length === 0}
-                            <div class="ml-auto mr-auto mt-4 text-textcolor2 italic max-w-2/3 wrap-break-word text-center">
-                                {language.aiGenerationWarning}
-                            </div>
-                        {/if}
-                        <!-- Creator notes/quote display -->
-                        {#if !DBState.currentChar.removedQuotes && DBState.currentChar.creatorNotes.length >= 2}
-                            <CreatorQuote
-                                quote={DBState.currentChar.creatorNotes}
-                                onRemove={() => {
-                                    const cha = DBState.currentChar
-                                    if (cha.type !== "group") {
-                                        cha.removedQuotes = true
-                                    }
-                                }}
-                            />
-                        {/if}
-                    {/if}
-                {/if}
             {/if}
 
             <!-- ======================================================== -->

--- a/src/styles.css
+++ b/src/styles.css
@@ -496,7 +496,7 @@ body {
   display: none;
 }
 
-.chat-message-container:first-of-type .dyna-icon {
+.chat-message-container:last-of-type .dyna-icon {
   display: block;
 }
 


### PR DESCRIPTION
## Problem

1. **Edit/Translate buttons broken after Lua script modifies chat**
   - When Lua scripts modified message content, the edit/translate buttons stopped working
   - Caused by manual `mount`/`unmount` DOM manipulation not syncing with Svelte's reactivity

2. **Scroll jumps on new message arrival**
   - Using `flex-col-reverse` caused scroll position to jump unexpectedly when new messages arrived
   - Made reading difficult while AI was generating responses

## Solution

1. Replaced `mount`/`unmount` with declarative `{#each}` in Chats.svelte
   - Svelte now properly tracks message changes and updates buttons accordingly

2. Changed from `flex-col-reverse` to `flex-col`
   - Adjusted layout order to match (first message renders first)
   - Moved scroll logic to parent component
   - Added auto-scroll that respects user's scroll position

## Files Changed

- `Chats.svelte` - Rewritten to use `{#each}` instead of manual DOM ops
- `DefaultChatScreen.svelte` - Now owns scroll logic, layout adjusted for `flex-col`
- `styles.css` - Reroll button selector fix
