### PR TITLE
perf: merge patch-based database sync for node server

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eventsource-parser": "^1.1.2",
     "exifr": "^7.1.3",
     "express": "^4.18.2",
+    "fast-json-patch": "^3.1.1",
     "fflate": "^0.8.1",
     "gpt-3-encoder": "^1.1.4",
     "gpt3-tokenizer": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
       fflate:
         specifier: ^0.8.1
         version: 0.8.1
@@ -989,6 +992,7 @@ packages:
 
   '@rollup/rollup-win32-arm64-msvc@4.40.1':
     resolution: {integrity: sha512-b2bcNm9Kbde03H+q+Jjw9tSfhYkzrDUf2d5MAd1bOJuVplXvFhWz7tRtWvD8/ORZi7qSCy0idW6tf2HgxSXQSg==}
+    cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.24.0':
@@ -1189,6 +1193,7 @@ packages:
   '@tauri-apps/cli-win32-arm64-msvc@2.5.0':
     resolution: {integrity: sha512-pFSHFK6b+o9y4Un8w0gGLwVyFTZaC3P0kQ7umRt/BLDkzD5RnQ4vBM7CF8BCU5nkwmEBUCZd7Wt3TWZxe41o6Q==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
     os: [win32]
 
   '@tauri-apps/cli-win32-ia32-msvc@2.5.0':
@@ -2072,6 +2077,9 @@ packages:
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
 
   fastq@1.16.0:
     resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
@@ -5754,6 +5762,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+
+  fast-json-patch@3.1.1: {}
 
   fastq@1.16.0:
     dependencies:

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -5,6 +5,14 @@ const htmlparser = require('node-html-parser');
 const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
 const fs = require('fs/promises')
 const crypto = require('crypto')
+const { applyPatch } = require('fast-json-patch')
+const { 
+    decodeRisuSave, 
+    encodeRisuSaveLegacy, 
+    calculateHash,
+    normalizeJSON,
+} = require('./utils.cjs')
+
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
 app.use(express.json({ limit: '100mb' }));
 app.use(express.raw({ type: 'application/octet-stream', limit: '100mb' }));
@@ -15,6 +23,20 @@ const sslPath = path.join(process.cwd(), 'server/node/ssl/certificate');
 const hubURL = 'https://sv.risuai.xyz'; 
 
 let password = ''
+
+// Configuration flags for patch-based sync
+let enablePatchSync = true
+const [major, minor, patch] = process.version.slice(1).split('.').map(Number);
+// v22.7.0, v23 and above have a bug with msgpackr that causes it to crash on encoding risu saves
+if (major >= 23 || (major === 22 && minor === 7 && patch === 0)) {
+    console.log(`[Server] Detected problematic Node.js version ${process.version}. Disabling patch-based sync.`);
+    enablePatchSync = false;
+}
+
+// In-memory database cache for patch-based sync
+let dbCache = {}
+let saveTimers = {}
+const SAVE_INTERVAL = 5000 // Save to disk after 5 seconds of inactivity
 
 const savePath = path.join(process.cwd(), "save")
 if(!existsSync(savePath)){
@@ -40,7 +62,7 @@ app.get('/', async (req, res, next) => {
         const mainIndex = await fs.readFile(path.join(process.cwd(), 'dist', 'index.html'))
         const root = htmlparser.parse(mainIndex)
         const head = root.querySelector('head')
-        head.innerHTML = `<script>globalThis.__NODE__ = true</script>` + head.innerHTML
+        head.innerHTML = `<script>globalThis.__NODE__ = true; globalThis.__PATCH_SYNC__ = ${enablePatchSync}</script>` + head.innerHTML
         
         res.send(root.toString())
     } catch (error) {
@@ -294,6 +316,26 @@ app.get('/api/read', async (req, res, next) => {
         return;
     }
     try {
+        const fullPath = path.join(savePath, filePath);
+        
+        // Stop any pending save timer for this file
+        if (saveTimers[filePath]) {
+            clearTimeout(saveTimers[filePath]);
+            delete saveTimers[filePath];
+        }
+        
+        // write to disk if available in cache
+        if (dbCache[filePath]) {
+            try {
+                let dataToSave = await encodeRisuSaveLegacy(dbCache[filePath]);
+                await fs.writeFile(fullPath, dataToSave);
+            } catch (error) {
+                console.error(`[Read] Error saving ${filePath}:`, error);
+            }
+            delete dbCache[filePath];
+        }
+
+        // read from disk
         if(!existsSync(path.join(savePath, filePath))){
             res.send();
         }
@@ -347,9 +389,10 @@ app.get('/api/list', async (req, res, next) => {
         return
     }
     try {
-        const data = (await fs.readdir(path.join(savePath))).map((v) => {
-            return Buffer.from(v, 'hex').toString('utf-8')
-        })
+        const data = (await fs.readdir(path.join(savePath)))
+            .map((v) => { return Buffer.from(v, 'hex').toString('utf-8') })
+            .filter((v) => { return v.startsWith(req.headers['key-prefix'].trim()) })
+
         res.send({
             success: true,
             content: data
@@ -384,11 +427,124 @@ app.post('/api/write', async (req, res, next) => {
 
     try {
         await fs.writeFile(path.join(savePath, filePath), fileContent);
+        
+        // Clear any pending save timer for this file
+        if (saveTimers[filePath]) {
+            clearTimeout(saveTimers[filePath]);
+            delete saveTimers[filePath];
+        }
+
+        // Clear cache for this file since it was directly written
+        if (dbCache[filePath]) delete dbCache[filePath];
+
         res.send({
             success: true
         });
     } catch (error) {
         next(error);
+    }
+});
+
+app.post('/api/patch', async (req, res, next) => {
+    // Check if patch sync is enabled
+    if (!enablePatchSync) {
+        res.status(404).send({
+            error: 'Patch sync is not enabled'
+        });
+        return;
+    }
+    
+    if(req.headers['risu-auth'].trim() !== password.trim()){
+        console.log('incorrect')
+        res.status(400).send({
+            error:'Password Incorrect'
+        });
+        return
+    }
+    const filePath = req.headers['file-path'];
+    const patch = req.body.patch;
+    const expectedHash = req.body.expectedHash;
+    
+    if (!filePath || !patch || !expectedHash) {
+        res.status(400).send({
+            error:'File path, patch, and expected hash required'
+        });
+        return;
+    }
+    if(!isHex(filePath)){
+        res.status(400).send({
+            error:'Invaild Path'
+        });
+        return;
+    }
+
+    try {
+        const decodedFilePath = Buffer.from(filePath, 'hex').toString('utf-8');
+        
+        // Load database into memory if not already cached
+        if (!dbCache[filePath]) {
+            const fullPath = path.join(savePath, filePath);
+            if (existsSync(fullPath)) {
+                const fileContent = await fs.readFile(fullPath);
+                dbCache[filePath] = normalizeJSON(await decodeRisuSave(fileContent));
+            } 
+            else {
+                dbCache[filePath] = {};
+            }
+        }
+        
+        const serverHash = calculateHash(dbCache[filePath]).toString(16);
+        
+        if (expectedHash !== serverHash) {
+            console.log(`[Patch] Hash mismatch for ${decodedFilePath}: expected=${expectedHash}..., server=${serverHash}...`);
+            res.status(409).send({
+                error: 'Hash mismatch - data out of sync',
+            });
+            return;
+        }
+        
+        // Apply patch to in-memory database
+        const result = applyPatch(dbCache[filePath], patch, true);
+
+        // Schedule save to disk (debounced)
+        if (saveTimers[filePath]) {
+            clearTimeout(saveTimers[filePath]);
+        }
+        saveTimers[filePath] = setTimeout(async () => {
+            try {
+                const fullPath = path.join(savePath, filePath);
+                let dataToSave = await encodeRisuSaveLegacy(dbCache[filePath]);
+                await fs.writeFile(fullPath, dataToSave);
+                // Create backup for database files after successful save
+                if (decodedFilePath.includes('database/database.bin')) {
+                    try {
+                        const timestamp = Math.floor(Date.now() / 100).toString();
+                        const backupFileName = `database/dbbackup-${timestamp}.bin`;
+                        const backupFilePath = Buffer.from(backupFileName, 'utf-8').toString('hex');
+                        const backupFullPath = path.join(savePath, backupFilePath);
+                        // Create backup using the same data that was just saved
+                        await fs.writeFile(backupFullPath, dataToSave);
+                    } catch (backupError) {
+                        console.error(`[Patch] Error creating backup:`, backupError);
+                    }
+                }
+            } catch (error) {
+                dbCache[filePath] = {}; // trigger hash mismatch on next patch and fallback to full save
+                console.error(`[Patch] Error saving ${filePath}:`, error);
+            } finally {
+                delete saveTimers[filePath];
+            }
+        }, SAVE_INTERVAL);
+
+        res.send({
+            success: true,
+            appliedOperations: result.length,
+        });
+    } catch (error) {
+        console.error(`[Patch] Error applying patch to ${filePath}:`, error.name);
+        res.status(500).send({
+            error: 'Patch application failed: ' + (error && error.message ? error.message : error)
+        });
     }
 });
 
@@ -427,12 +583,14 @@ async function startServer() {
             https.createServer(httpsOptions, app).listen(port, () => {
                 console.log("[Server] HTTPS server is running.");
                 console.log(`[Server] https://localhost:${port}/`);
+                console.log(`[Server] Patch sync: ${enablePatchSync ? 'ENABLED' : 'DISABLED'}`);
             });
         } else {
             // HTTP
             app.listen(port, () => {
                 console.log("[Server] HTTP server is running.");
                 console.log(`[Server] http://localhost:${port}/`);
+                console.log(`[Server] Patch sync: ${enablePatchSync ? 'ENABLED' : 'DISABLED'}`);
             });
         }
     } catch (error) {

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -14,8 +14,8 @@ const {
 } = require('./utils.cjs')
 
 app.use(express.static(path.join(process.cwd(), 'dist'), {index: false}));
-app.use(express.json({ limit: '100mb' }));
-app.use(express.raw({ type: 'application/octet-stream', limit: '100mb' }));
+app.use(express.json({ limit: '200mb' }));
+app.use(express.raw({ type: 'application/octet-stream', limit: '200mb' }));
 app.use(express.text({ limit: '100mb' }));
 const {pipeline} = require('stream/promises')
 const https = require('https');

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -417,7 +417,7 @@ app.get('/api/read', async (req, res, next) => {
 
     if(!isHex(filePath)){
         res.status(400).send({
-            error:'Invaild Path'
+            error:'Invalid Path'
         });
         return;
     }
@@ -471,7 +471,7 @@ app.get('/api/remove', async (req, res, next) => {
     }
     if(!isHex(filePath)){
         res.status(400).send({
-            error:'Invaild Path'
+            error:'Invalid Path'
         });
         return;
     }
@@ -497,7 +497,7 @@ app.get('/api/list', async (req, res, next) => {
     try {
         const data = (await fs.readdir(path.join(savePath)))
             .map((v) => { return Buffer.from(v, 'hex').toString('utf-8') })
-            .filter((v) => { return v.startsWith(req.headers['key-prefix'].trim()) })
+            .filter((v) => { return v.startsWith((req.headers['key-prefix'] || '').trim()) })
 
         res.send({
             success: true,
@@ -526,7 +526,7 @@ app.post('/api/write', async (req, res, next) => {
     }
     if(!isHex(filePath)){
         res.status(400).send({
-            error:'Invaild Path'
+            error:'Invalid Path'
         });
         return;
     }
@@ -687,7 +687,7 @@ app.post('/api/patch', async (req, res, next) => {
     }
     if(!isHex(filePath)){
         res.status(400).send({
-            error:'Invaild Path'
+            error:'Invalid Path'
         });
         return;
     }

--- a/server/node/utils.cjs
+++ b/server/node/utils.cjs
@@ -109,7 +109,6 @@ class RisuSaveDecoder {
     }
 
     async decode(data) {
-        console.log('Decoding RisuSave data');
         let offset = magicRisuSaveHeader.length;
         let db = {};
         
@@ -149,8 +148,6 @@ class RisuSaveDecoder {
                 content: new TextDecoder().decode(blockData)
             });
         }
-
-        console.log('blocks', this.blocks);
         
         for (const key in this.blocks) {
             switch (this.blocks[key].type) {
@@ -178,18 +175,19 @@ class RisuSaveDecoder {
                     break;
                 }
                 default: {
-                    console.warn(`Not Implemented RisuSaveType: ${this.blocks[key].type} for ${this.blocks[key].name}`);
+                    //console.warn(`Not Implemented RisuSaveType: ${this.blocks[key].type} for ${this.blocks[key].name}`);
                 }
             }
         }
-
+        if(!Array.isArray(db.characters)){
+            db.characters = [];
+        }
         // Fix botpreset bugs
         if (!Array.isArray(db.botPresets) || db.botPresets.length === 0) {
             db.botPresets = [presetTemplate];
             db.botPresetsId = 0;
         }
 
-        console.log('Decoded RisuSave data', db);
         return db;
     }
 }
@@ -228,7 +226,6 @@ async function decodeRisuSave(data) {
     } catch (error) {
         console.error('Error decoding RisuSave data:', error);
         try {
-            console.log('risudecode');
             const risuSaveHeader = new Uint8Array(Buffer.from("\u0000\u0000RISU", 'utf-8'));
             const realData = data.subarray(risuSaveHeader.length);
             const dec = unpackr.decode(realData);

--- a/server/node/utils.cjs
+++ b/server/node/utils.cjs
@@ -1,0 +1,386 @@
+const { Packr, Unpackr, decode } = require('msgpackr');
+const fflate = require('fflate');
+
+// Magic headers for different save formats
+const magicHeader = new Uint8Array([0, 82, 73, 83, 85, 83, 65, 86, 69, 0, 7]); 
+const magicCompressedHeader = new Uint8Array([0, 82, 73, 83, 85, 83, 65, 86, 69, 0, 8]);
+const magicStreamCompressedHeader = new Uint8Array([0, 82, 73, 83, 85, 83, 65, 86, 69, 0, 9]);
+const magicRisuSaveHeader = new TextEncoder().encode("RISUSAVE\0");
+
+// Save type enums
+const RisuSaveType = {
+    CONFIG: 0,
+    ROOT: 1,
+    CHARACTERWITHCHAT: 2,
+    CHAT: 3,
+    BOTPRESET: 4,
+    MODULES: 5
+};
+
+// Packr/Unpackr instances
+const packr = new Packr({
+    useRecords: false
+});
+
+const unpackr = new Unpackr({
+    int64AsType: 'number',
+    useRecords: false
+});
+
+// Preset template for bot presets
+const presetTemplate = {
+    name: "Default",
+    // Add other default properties as needed
+    // This should match the presetTemplate from your client code
+};
+
+/**
+ * Check compression streams availability and polyfill if needed
+ */
+async function checkCompressionStreams() {
+    if (!CompressionStream) {
+        const { makeCompressionStream } = await import('compression-streams-polyfill/ponyfill');
+        globalThis.CompressionStream = makeCompressionStream(TransformStream);
+    }
+    if (!DecompressionStream) {
+        const { makeDecompressionStream } = await import('compression-streams-polyfill/ponyfill');
+        globalThis.DecompressionStream = makeDecompressionStream(TransformStream);
+    }
+}
+
+/**
+ * Check the header type of saved data
+ * @param {Uint8Array} data - The data to check
+ * @returns {string} - The header type
+ */
+function checkHeader(data) {
+    let header = 'raw';
+
+    if (data.length < magicHeader.length) {
+        return false;
+    }
+
+    for (let i = 0; i < magicHeader.length; i++) {
+        if (data[i] !== magicHeader[i]) {
+            header = 'none';
+            break;
+        }
+    }
+
+    if (header === 'none') {
+        header = 'compressed';
+        for (let i = 0; i < magicCompressedHeader.length; i++) {
+            if (data[i] !== magicCompressedHeader[i]) {
+                header = 'none';
+                break;
+            }
+        }
+    }
+
+    if (header === 'none') {
+        header = 'stream';
+        for (let i = 0; i < magicStreamCompressedHeader.length; i++) {
+            if (data[i] !== magicStreamCompressedHeader[i]) {
+                header = 'none';
+                break;
+            }
+        }
+    }
+
+    if (header === 'none') {
+        header = 'risusave';
+        for (let i = 0; i < magicRisuSaveHeader.length; i++) {
+            if (data[i] !== magicRisuSaveHeader[i]) {
+                header = 'none';
+                break;
+            }
+        }
+    }
+
+    return header;
+}
+
+/**
+ * RisuSave decoder class
+ */
+class RisuSaveDecoder {
+    constructor() {
+        this.blocks = [];
+    }
+
+    async decode(data) {
+        console.log('Decoding RisuSave data');
+        let offset = magicRisuSaveHeader.length;
+        let db = {};
+        
+        while (offset < data.length) {
+            const type = data[offset];
+            const compression = data[offset + 1] === 1;
+            offset += 2;
+
+            const nameLength = data[offset];
+            offset += 1;
+            const name = new TextDecoder().decode(data.subarray(offset, offset + nameLength));
+            offset += nameLength;
+
+            const newArrayBuf = new ArrayBuffer(4);
+            const lengthSubUint8Buf = data.slice(offset, offset + 4);
+            new Uint8Array(newArrayBuf).set(lengthSubUint8Buf);
+            const length = new Uint32Array(newArrayBuf)[0];
+            offset += 4;
+
+            let blockData = data.subarray(offset, offset + length);
+            offset += length;
+
+            if (compression) {
+                await checkCompressionStreams();
+                const cs = new DecompressionStream('gzip');
+                const writer = cs.writable.getWriter();
+                writer.write(blockData);
+                writer.close();
+                const buf = await new Response(cs.readable).arrayBuffer();
+                blockData = new Uint8Array(buf);
+            }
+
+            this.blocks.push({
+                name,
+                type,
+                compression,
+                content: new TextDecoder().decode(blockData)
+            });
+        }
+
+        console.log('blocks', this.blocks);
+        
+        for (const key in this.blocks) {
+            switch (this.blocks[key].type) {
+                case RisuSaveType.ROOT: {
+                    const rootData = JSON.parse(this.blocks[key].content);
+                    for (const rootKey in rootData) {
+                        if (!db[rootKey]) {
+                            db[rootKey] = rootData[rootKey];
+                        }
+                    }
+                    break;
+                }
+                case RisuSaveType.CHARACTERWITHCHAT: {
+                    db.characters ??= [];
+                    const character = JSON.parse(this.blocks[key].content);
+                    db.characters.push(character);
+                    break;
+                }
+                case RisuSaveType.BOTPRESET: {
+                    db.botPresets = JSON.parse(this.blocks[key].content);
+                    break;
+                }
+                case RisuSaveType.MODULES: {
+                    db.modules = JSON.parse(this.blocks[key].content);
+                    break;
+                }
+                default: {
+                    console.warn(`Not Implemented RisuSaveType: ${this.blocks[key].type} for ${this.blocks[key].name}`);
+                }
+            }
+        }
+
+        // Fix botpreset bugs
+        if (!Array.isArray(db.botPresets) || db.botPresets.length === 0) {
+            db.botPresets = [presetTemplate];
+            db.botPresetsId = 0;
+        }
+
+        console.log('Decoded RisuSave data', db);
+        return db;
+    }
+}
+
+/**
+ * Decode RisuSave data
+ * @param {Uint8Array} data - The data to decode
+ * @returns {Promise<Object>} - The decoded database
+ */
+async function decodeRisuSave(data) {
+    try {
+        const header = checkHeader(data);
+        switch (header) {
+            case "compressed":
+                data = data.slice(magicCompressedHeader.length);
+                return decode(fflate.decompressSync(data));
+            case "raw":
+                data = data.slice(magicHeader.length);
+                return unpackr.decode(data);
+            case "stream": {
+                await checkCompressionStreams();
+                data = data.slice(magicStreamCompressedHeader.length);
+                const cs = new DecompressionStream('gzip');
+                const writer = cs.writable.getWriter();
+                writer.write(data);
+                writer.close();
+                const buf = await new Response(cs.readable).arrayBuffer();
+                return unpackr.decode(new Uint8Array(buf));
+            }
+            case "risusave": {
+                const decoder = new RisuSaveDecoder();
+                return await decoder.decode(data);
+            }
+        }
+        return unpackr.decode(data);
+    } catch (error) {
+        console.error('Error decoding RisuSave data:', error);
+        try {
+            console.log('risudecode');
+            const risuSaveHeader = new Uint8Array(Buffer.from("\u0000\u0000RISU", 'utf-8'));
+            const realData = data.subarray(risuSaveHeader.length);
+            const dec = unpackr.decode(realData);
+            return dec;
+        } catch (error) {
+            const buf = Buffer.from(fflate.decompressSync(Buffer.from(data)));
+            try {
+                return JSON.parse(buf.toString('utf-8'));
+            } catch (error) {
+                return unpackr.decode(buf);
+            }
+        }
+    }
+}
+
+/**
+ * Encode data using legacy format
+ * @param {Object} data - The data to encode
+ * @param {string} compression - Compression type ('noCompression' or 'compression')
+ * @returns {Uint8Array} - The encoded data
+ */
+function encodeRisuSaveLegacy(data, compression = 'noCompression') {
+    let encoded = packr.encode(data);
+    if (compression === 'compression') {
+        encoded = fflate.compressSync(encoded);
+        const result = new Uint8Array(encoded.length + magicCompressedHeader.length);
+        result.set(magicCompressedHeader, 0);
+        result.set(encoded, magicCompressedHeader.length);
+        return result;
+    } else {
+        const result = new Uint8Array(encoded.length + magicHeader.length);
+        result.set(magicHeader, 0);
+        result.set(encoded, magicHeader.length);
+        return result;
+    }
+}
+
+/**
+ * Calculate compositional hash for an object
+ * @param {Object} obj - The object to hash
+ * @returns {string} - The hash string
+ */
+
+const PRIME_MULTIPLIER = 31;
+    
+const SEED_OBJECT = 17;
+const SEED_ARRAY = 19;
+const SEED_STRING = 23;
+const SEED_NUMBER = 29;
+const SEED_BOOLEAN = 31;
+const SEED_NULL = 37;
+
+function calculateHash(node) {
+    if (node === null || node === undefined) return SEED_NULL;
+    switch (typeof node) {
+        case 'object':
+            if (Array.isArray(node)) {
+                let arrayHash = SEED_ARRAY;
+                for (const item of node)
+                    arrayHash = (Math.imul(arrayHash, PRIME_MULTIPLIER) + calculateHash(item)) >>> 0;
+                return arrayHash;
+            } else {
+                let objectHash = SEED_OBJECT;
+                for (const key in node)
+                    objectHash += (Math.imul(calculateHash(key), PRIME_MULTIPLIER) + calculateHash(node[key]));
+                return objectHash >>> 0;
+            }
+        case 'string':
+            let strHash = 2166136261;
+            for (let i = 0; i < node.length; i++)
+                strHash = Math.imul(strHash ^ node.charCodeAt(i), 16777619);
+            return Math.imul(SEED_STRING, PRIME_MULTIPLIER) + (strHash >>> 0);
+        case 'number':
+            let numHash;
+            if (Number.isInteger(node) && node >= -2147483648 && node <= 2147483647) 
+                numHash = node >>> 0; 
+            else {
+                const str = node.toString();
+                numHash = 2166136261;
+                for (let i = 0; i < str.length; i++) 
+                    numHash = Math.imul(numHash ^ str.charCodeAt(i), 16777619);
+                numHash = numHash >>> 0;
+            }
+            return Math.imul(SEED_NUMBER, PRIME_MULTIPLIER) + numHash;
+        case 'boolean':
+            return Math.imul(SEED_BOOLEAN, PRIME_MULTIPLIER) + (node ? 1 : 0);
+            
+        default:
+            return 0;
+    }
+}
+
+/**
+ * Normalize JSON data for consistent hashing
+ * @param {*} value - The value to normalize
+ * @returns {*} - The normalized value
+ */
+function normalizeJSON(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value !== 'object') {
+        if (typeof value === 'number' && !isFinite(value)) return null;
+        if (typeof value === 'function' || 
+            typeof value === 'symbol' || 
+            typeof value === 'bigint') 
+            return undefined; 
+        return value;
+    }
+    if (value instanceof Date) return value.toISOString();
+    if (value instanceof RegExp || value instanceof Error) return {};
+    if (Array.isArray(value)) {
+        const result = [];
+        for (const item of value) {
+            if (item === undefined) {
+                result.push(null);
+            } else {
+                const normalized = normalizeJSON(item);
+                result.push(normalized === undefined ? null : normalized);
+            }
+        }
+        return result;
+    }
+    const result = {};
+    for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+            const propValue = value[key];
+            if (propValue !== undefined) {
+                const normalized = normalizeJSON(propValue);
+                if (normalized !== undefined) 
+                    result[key] = normalized;
+            }
+        }
+    }
+    return result;
+}
+
+module.exports = {
+    // Classes
+    RisuSaveDecoder,
+    
+    // Functions
+    decodeRisuSave,
+    encodeRisuSaveLegacy,
+    calculateHash,
+    normalizeJSON,
+    checkHeader,
+    checkCompressionStreams,
+    
+    // Constants
+    RisuSaveType,
+    magicHeader,
+    magicCompressedHeader,
+    magicStreamCompressedHeader,
+    magicRisuSaveHeader,
+    presetTemplate
+};

--- a/server/node/utils.cjs
+++ b/server/node/utils.cjs
@@ -154,7 +154,8 @@ class RisuSaveDecoder {
                 case RisuSaveType.ROOT: {
                     const rootData = JSON.parse(this.blocks[key].content);
                     for (const rootKey in rootData) {
-                        if (!db[rootKey]) {
+                        // Filter out internal keys like __directory (same as client)
+                        if (!db[rootKey] && !rootKey.startsWith('__')) {
                             db[rootKey] = rootData[rootKey];
                         }
                     }

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -481,6 +481,7 @@ export async function saveDb(){
                     if (supportsPatchSync) {
                         const patchData = await patcher.set(db, toSave)
                         saved = await forageStorage.patchItem('database/database.bin', patchData);
+                        if(!saved) await patcher.init(db)
                     }
                     if (!saved) {
                         await forageStorage.setItem('database/database.bin', dbData);

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -463,7 +463,7 @@ export async function saveDb(){
                 continue
             }
 
-            await encoder.set(db, toSave)
+            await encoder.set(db, safeStructuredClone(toSave))
             const encoded = encoder.encode()
             if(!encoded){
                 await sleep(1000)
@@ -479,7 +479,7 @@ export async function saveDb(){
                 if(!forageStorage.isAccount){
                     let saved = false
                     if (supportsPatchSync) {
-                        const patchData = await patcher.set(db, toSave)
+                        const patchData = await patcher.set(db, safeStructuredClone(toSave))
                         saved = await forageStorage.patchItem('database/database.bin', patchData);
                         if(!saved) await patcher.init(db)
                     }

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -481,11 +481,16 @@ export async function saveDb(){
                     if (supportsPatchSync) {
                         const patchData = await patcher.set(db, safeStructuredClone(toSave))
                         saved = await forageStorage.patchItem('database/database.bin', patchData);
-                        if(!saved) await patcher.init(db)
                     }
                     if (!saved) {
                         await forageStorage.setItem('database/database.bin', dbData);
                         await forageStorage.setItem(`database/dbbackup-${(Date.now()/100).toFixed()}.bin`, dbData);
+
+                        if (supportsPatchSync) {
+                            const decodedDb = await decodeRisuSave(dbData);
+                            globalThis.decoded = decodedDb
+                            await patcher.init(decodedDb);
+                        }
                     }
                 }
                 if(forageStorage.isAccount){

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -12,8 +12,8 @@ import { convertFileSrc, invoke } from "@tauri-apps/api/core"
 import { v4 as uuidv4, v4 } from 'uuid';
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { get } from "svelte/store";
-import {open} from '@tauri-apps/plugin-shell'
-import { setDatabase, type Database, defaultSdDataFunc, getDatabase, type character, appVer } from "./storage/database.svelte";
+import { open } from '@tauri-apps/plugin-shell'
+import { setDatabase, type Database, defaultSdDataFunc, getDatabase, type character, appVer, getCurrentCharacter, onDatabaseUpdate } from "./storage/database.svelte";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkRisuUpdate } from "./update";
 import { MobileGUI, botMakerMode, selectedCharID, loadedStore, DBState, LoadingStatusState } from "./stores.svelte";
@@ -372,7 +372,7 @@ export async function saveDb(){
         const debounceTime = 500; // 500 milliseconds
         let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
-        selectedCharID.subscribe((v) => {
+        const unsubscribeSel = selectedCharID.subscribe((v) => {
             selIdState = v
         })
 
@@ -385,42 +385,58 @@ export async function saveDb(){
             }, debounceTime);
         }
 
-        $effect(() => {
-            DBState.db.botPresetsId
-            DBState.db.botPresets.length
-            changeTracker.botPreset = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            $state.snapshot(DBState.db.modules)
-            changeTracker.modules = true
-            saveTimeoutExecute()
-        })
-        $effect(() => {
-            for(const key in DBState.db){
-                if(key !== 'characters' && key !== 'botPresets' && key !== 'modules'){
-                    $state.snapshot(DBState.db[key])
-                }
+        function updateChangeTrackerForCharacter(char: { chaId?: string, chatPage?: number, chats?: { id?: string }[] } | null | undefined) {
+            if (!char?.chaId) {
+                return
             }
-            if(DBState?.db?.characters?.[selIdState]){
-                for(const key in DBState.db.characters[selIdState]){
-                    if(key !== 'chats'){
-                        $state.snapshot(DBState.db.characters[selIdState][key])
-                    }
-                }
-                $state.snapshot(DBState.db.characters[selIdState].chats)
-                if(changeTracker.character[0] !== DBState.db.characters[selIdState]?.chaId){
-                    changeTracker.character.unshift(DBState.db.characters[selIdState]?.chaId)
-                }
-                if(
-                    changeTracker.chat[0]?.[0] !== DBState.db.characters[selIdState]?.chaId ||
-                    changeTracker.chat[0]?.[1] !== DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id
-                ){
-                    changeTracker.chat.unshift([DBState.db.characters[selIdState]?.chaId, DBState.db.characters[selIdState]?.chats[DBState.db.characters[selIdState]?.chatPage].id])
-                }
+            if (changeTracker.character[0] !== char.chaId) {
+                changeTracker.character.unshift(char.chaId)
             }
+            const chatId = char.chats?.[char.chatPage ?? 0]?.id
+            if (chatId && (
+                changeTracker.chat[0]?.[0] !== char.chaId ||
+                changeTracker.chat[0]?.[1] !== chatId
+            )) {
+                changeTracker.chat.unshift([char.chaId, chatId])
+            }
+        }
+
+        const unsubscribeDb = onDatabaseUpdate((info) => {
+            // console.log('[DBProxy] Database updated at path:', info.path.join('.'))
+            const rootKey = info.path[0]
+
+            if (rootKey === 'botPresets' || rootKey === 'botPresetsId') {
+                changeTracker.botPreset = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'modules') {
+                changeTracker.modules = true
+                saveTimeoutExecute()
+                return
+            }
+
+            if (rootKey === 'characters') {
+                const rawIndex = info.path[1]
+                const index = typeof rawIndex === 'number'
+                    ? rawIndex
+                    : (typeof rawIndex === 'string' && /^\d+$/.test(rawIndex) ? Number(rawIndex) : selIdState)
+                const targetChar = DBState?.db?.characters?.[index ?? selIdState]
+                const fallbackChar = info.oldValue && typeof info.oldValue === 'object' ? info.oldValue as any : null
+                updateChangeTrackerForCharacter(targetChar ?? fallbackChar)
+                saveTimeoutExecute()
+                return
+            }
+
+            updateChangeTrackerForCharacter(DBState?.db?.characters?.[selIdState])
             saveTimeoutExecute()
         })
+
+        return () => {
+            unsubscribeSel()
+            unsubscribeDb()
+        }
     })
 
     let savetrys = 0

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -416,6 +416,10 @@ export async function saveDb() {
                 await encoder.init(getDatabase(), {
                     compression: forageStorage.isAccount
                 })
+                // Also reinitialize patcher to match new DB state
+                if (supportsPatchSync) {
+                    await patcher.init(getDatabase())
+                }
                 requiresFullEncoderReload.state = false
             }
 

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -16,6 +16,96 @@ import { type HypaV3Settings, type HypaV3Preset, createHypaV3Preset } from '../p
 export let appVer = "166.3.0"
 export let webAppSubVer = ''
 
+type DatabaseUpdatePathKey = string | number | symbol
+
+export interface DatabaseUpdateInfo {
+    path: DatabaseUpdatePathKey[]
+    value: unknown
+    oldValue: unknown
+    type: 'set' | 'delete'
+}
+
+const databaseUpdateListeners = new Set<(info: DatabaseUpdateInfo) => void>()
+const dbProxyInstances = new WeakSet<object>()
+const dbProxyCache = new WeakMap<object, object>()
+
+function emitDatabaseUpdate(info: DatabaseUpdateInfo) {
+    for (const listener of databaseUpdateListeners) {
+        try {
+            listener(info)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+}
+
+function normalizePathKey(target: object, prop: PropertyKey): DatabaseUpdatePathKey {
+    if (Array.isArray(target) && typeof prop === 'string' && /^\d+$/.test(prop)) {
+        return Number(prop)
+    }
+    return prop
+}
+
+function createDatabaseProxy<T extends object>(target: T, path: DatabaseUpdatePathKey[] = []): T {
+    if (!target || typeof target !== 'object') {
+        return target
+    }
+    if (dbProxyInstances.has(target)) {
+        return target
+    }
+    const cached = dbProxyCache.get(target as object)
+    if (cached) {
+        return cached as T
+    }
+
+    const proxy = new Proxy(target, {
+        get(obj, prop, receiver) {
+            const value = Reflect.get(obj, prop, receiver)
+            if (value && typeof value === 'object') {
+                return createDatabaseProxy(value, [...path, normalizePathKey(obj, prop)])
+            }
+            return value
+        },
+        set(obj, prop, value, receiver) {
+            // console.log('[DBProxy] Setting database property', [...path, normalizePathKey(obj, prop)].join('.'))
+            const oldValue = Reflect.get(obj, prop, receiver)
+            const result = Reflect.set(obj, prop, value, receiver)
+            if (oldValue !== value) {
+                emitDatabaseUpdate({
+                    path: [...path, normalizePathKey(obj, prop)],
+                    value,
+                    oldValue,
+                    type: 'set'
+                })
+            }
+            return result
+        },
+        deleteProperty(obj, prop) {
+            // console.log('[DBProxy] Deleting database property', [...path, normalizePathKey(obj, prop)].join('.'))
+            const oldValue = Reflect.get(obj, prop)
+            const result = Reflect.deleteProperty(obj, prop)
+            emitDatabaseUpdate({
+                path: [...path, normalizePathKey(obj, prop)],
+                value: undefined,
+                oldValue,
+                type: 'delete'
+            })
+            return result
+        }
+    })
+
+    dbProxyCache.set(target as object, proxy)
+    dbProxyInstances.add(proxy as object)
+    return proxy
+}
+
+export function onDatabaseUpdate(listener: (info: DatabaseUpdateInfo) => void) {
+    databaseUpdateListeners.add(listener)
+    return () => {
+        databaseUpdateListeners.delete(listener)
+    }
+}
+
 
 export function setDatabase(data:Database){
     if(checkNullish(data.characters)){
@@ -584,7 +674,7 @@ export function setDatabase(data:Database){
 }
 
 export function setDatabaseLite(data:Database){
-    DBState.db = data
+    DBState.db = createDatabaseProxy(data)
 }
 
 interface getDatabaseOptions{

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -43,12 +43,13 @@ export class NodeStorage{
         }
         return data
     }
-    async keys():Promise<string[]>{
+    async keys(prefix:string = ""):Promise<string[]>{
         await this.checkAuth()
         const da = await fetch('/api/list', {
             method: "GET",
             headers:{
-                'risu-auth': auth
+                'risu-auth': auth,
+                'key-prefix': prefix
             }
         })
         const data = await da.json()
@@ -76,6 +77,29 @@ export class NodeStorage{
         if(data.error){
             throw data.error
         }
+    }
+
+    async patchItem(key: string, patchData: {patch: any[], expectedHash: string}): Promise<boolean> {
+        await this.checkAuth()
+        
+        const da = await fetch('/api/patch', {
+            method: "POST",
+            body: JSON.stringify(patchData),
+            headers: {
+                'content-type': 'application/json',
+                'file-path': Buffer.from(key, 'utf-8').toString('hex'),
+                'risu-auth': auth
+            }
+        })
+        
+        if(da.status < 200 || da.status >= 300){
+            return false
+        }
+        const data = await da.json()
+        if(data.error){
+            return false
+        }
+        return true
     }
 
     private async checkAuth(){

--- a/src/ts/storage/risuSave.ts
+++ b/src/ts/storage/risuSave.ts
@@ -531,7 +531,6 @@ function normalizeJSON(value: any): any {
 export class RisuSavePatcher {
     private lastSyncedDb: any;
     private hashBlocks: { [key: string]: number } = {};
-    private curPatch: any[] = [];
 
     hash(): string {
         

--- a/src/ts/storage/risuSave.ts
+++ b/src/ts/storage/risuSave.ts
@@ -335,6 +335,9 @@ export class RisuSaveDecoder {
                 }
             }
         }
+        if(!Array.isArray(db.characters)){
+            db.characters = [];
+        }
         //to fix botpreset bugs
         if(!Array.isArray(db.botPresets) || db.botPresets.length === 0){
             db.botPresets = [presetTemplate]


### PR DESCRIPTION
## Summary
- Merges [kangjoseph90/patchsync](https://github.com/kwaroran/RisuAI/compare/main...kangjoseph90:RisuAI:patchsync) branch with adaptations for upstream/main changes
- Implements patch-based database sync using `fast-json-patch` for node server environment
- Only sends changed data instead of full database on each save
- Falls back to full save if patch fails (hash mismatch, etc.)

## Changes
- Merge kangjoseph90's patchsync branch
- Fix hash mismatch caused by `__directory` field filtering difference between client/server
- Reinitialize patcher on backup restore to prevent oversized patches
- Increase body limit to 200mb for large patches

## Result
- Reduced save payload from ~78MB to ~2MB on typical edits
